### PR TITLE
feat(api): add search filter to landing profile endpoints

### DIFF
--- a/apps/api/src/dtos/landing-profile.dto.ts
+++ b/apps/api/src/dtos/landing-profile.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
-import { IsEnum, IsInt, IsOptional, Max, Min } from 'class-validator';
+import { IsEnum, IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
 import { StaffRole, StaffStatus, StudentStatus } from 'generated/enums';
 
 export class StaffLandingProfileQueryDto {
@@ -21,6 +21,14 @@ export class StaffLandingProfileQueryDto {
   @IsOptional()
   @IsEnum(StaffStatus)
   status?: StaffStatus;
+
+  @ApiPropertyOptional({
+    description: 'Search by staff name (case-insensitive)',
+    example: 'Nguyen Van',
+  })
+  @IsOptional()
+  @IsString()
+  search?: string;
 
   @ApiPropertyOptional({
     minimum: 1,
@@ -45,6 +53,14 @@ export class StudentLandingProfileQueryDto {
   @IsOptional()
   @IsEnum(StudentStatus)
   status?: StudentStatus;
+
+  @ApiPropertyOptional({
+    description: 'Search by student full name (case-insensitive)',
+    example: 'Le Van',
+  })
+  @IsOptional()
+  @IsString()
+  search?: string;
 
   @ApiPropertyOptional({
     minimum: 1,

--- a/apps/api/src/staff/staff.service.ts
+++ b/apps/api/src/staff/staff.service.ts
@@ -1278,6 +1278,7 @@ export class StaffService {
       roles: {
         has: role,
       },
+      ...buildNameSearchWhere(query.search),
     };
 
     const [total, rows] = await Promise.all([

--- a/apps/api/src/student/student.service.ts
+++ b/apps/api/src/student/student.service.ts
@@ -1170,6 +1170,13 @@ export class StudentService {
         : 100;
 
     const where: Prisma.StudentInfoWhereInput = { status };
+    const trimmedSearch = query.search?.trim();
+    if (trimmedSearch) {
+      where.fullName = {
+        contains: trimmedSearch,
+        mode: 'insensitive',
+      };
+    }
 
     const [total, rows] = await Promise.all([
       this.prisma.studentInfo.count({ where }),


### PR DESCRIPTION
## Summary
- Add optional `search` query param to `GET /staff/landing-profiles` and `GET /student/landing-profiles`
- Staff search reuses existing `buildNameSearchWhere` name matching
- Student search filters `fullName` case-insensitively

## Why
The landing CMS import panel needs server-side name search so editors can find instructors and students outside the default API result limits.

## Test plan
- [ ] `GET /staff/landing-profiles?search=nguyen&limit=10` returns matching active teachers
- [ ] `GET /student/landing-profiles?search=le&limit=10` returns matching active students
- [ ] Import search in `unicorns-edu-landing` admin finds records beyond the first page


Made with [Cursor](https://cursor.com)