### PR TITLE
feat(courses): expand class_categories → courses with dual-write

### DIFF
--- a/apps/api/prisma/schema/learning.prisma
+++ b/apps/api/prisma/schema/learning.prisma
@@ -2,6 +2,7 @@ model Class {
   id                            String                      @id
   name                          String
   classCategoryId               String                      @map("class_category_id")
+  courseId                       String                      @map("course_id")
   status                        ClassStatus                 @default(running)
   maxStudents                   Int                         @default(15) @map("max_students")
   allowancePerSessionPerStudent Int                         @default(0) @map("allowance_per_session_per_student")
@@ -27,13 +28,16 @@ model Class {
   topics                        Topic[]
   trainingManager               StaffInfo?                  @relation("ClassTrainingManager", fields: [trainingManagerStaffId], references: [id])
   classCategory                 ClassCategory               @relation(fields: [classCategoryId], references: [id])
+  course                        Course                      @relation(fields: [courseId], references: [id])
 
   @@index([trainingManagerStaffId])
   @@index([classCategoryId])
+  @@index([courseId])
   @@map("classes")
 }
 
 /// Phân loại lớp có thể tuỳ chỉnh (thêm/sửa/xoá) qua admin, thay cho enum cố định trước đây.
+/// Mỗi ClassCategory có đúng một Course cùng id (expand→contract: song song trong giai đoạn expand).
 model ClassCategory {
   id        String   @id @default(uuid())
   name      String
@@ -42,8 +46,40 @@ model ClassCategory {
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(6)
   classes   Class[]
+  course    Course?  @relation(fields: [id], references: [id])
 
   @@map("class_categories")
+}
+
+/// Khoá học — chương trình học độc lập, sở hữu Ngân hàng câu hỏi, thang độ khó, thời hạn mặc định.
+/// Trong giai đoạn expand, mỗi Course có đúng một ClassCategory cùng id.
+model Course {
+  id                 String                @id @default(uuid())
+  name               String
+  sortOrder          Int                   @default(0) @map("sort_order")
+  isActive           Boolean               @default(true) @map("is_active")
+  defaultDurationDays Int?                  @map("default_duration_days")
+  createdAt          DateTime              @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt          DateTime              @updatedAt @map("updated_at") @db.Timestamptz(6)
+  classCategory      ClassCategory?
+  classes            Class[]
+  difficultyLevels   CourseDifficultyLevel[]
+
+  @@map("courses")
+}
+
+/// Mức độ khó của một Khoá học — thang do từng Khoá học tự định nghĩa.
+model CourseDifficultyLevel {
+  id        String  @id @default(uuid())
+  courseId   String  @map("course_id")
+  name      String
+  sortOrder Int     @default(0) @map("sort_order")
+  isActive  Boolean @default(true) @map("is_active")
+  course    Course  @relation(fields: [courseId], references: [id], onDelete: Cascade)
+
+  @@unique([courseId, name])
+  @@index([courseId])
+  @@map("course_difficulty_levels")
 }
 
 model ClassTeacher {

--- a/apps/api/prisma/schema/migrations/20260905100000_add_courses_and_difficulty_levels/migration.sql
+++ b/apps/api/prisma/schema/migrations/20260905100000_add_courses_and_difficulty_levels/migration.sql
@@ -1,0 +1,63 @@
+-- CreateTable
+CREATE TABLE "courses" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "sort_order" INTEGER NOT NULL DEFAULT 0,
+    "is_active" BOOLEAN NOT NULL DEFAULT true,
+    "default_duration_days" INTEGER,
+    "created_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ(6) NOT NULL,
+
+    CONSTRAINT "courses_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "course_difficulty_levels" (
+    "id" TEXT NOT NULL,
+    "course_id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "sort_order" INTEGER NOT NULL DEFAULT 0,
+    "is_active" BOOLEAN NOT NULL DEFAULT true,
+
+    CONSTRAINT "course_difficulty_levels_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "course_difficulty_levels_course_id_name_key" ON "course_difficulty_levels"("course_id", "name");
+
+-- CreateIndex
+CREATE INDEX "course_difficulty_levels_course_id_idx" ON "course_difficulty_levels"("course_id");
+
+-- Backfill courses from class_categories (same id, same data)
+INSERT INTO "courses" ("id", "name", "sort_order", "is_active", "created_at", "updated_at")
+SELECT "id", "name", "sort_order", "is_active", "created_at", "updated_at"
+FROM "class_categories";
+
+-- AddColumn course_id to classes
+ALTER TABLE "classes" ADD COLUMN "course_id" TEXT;
+
+-- Backfill course_id from class_category_id
+UPDATE "classes" SET "course_id" = "class_category_id";
+
+-- Set NOT NULL after backfill
+ALTER TABLE "classes" ALTER COLUMN "course_id" SET NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "classes" ADD CONSTRAINT "classes_course_id_fkey" FOREIGN KEY ("course_id") REFERENCES "courses"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "course_difficulty_levels" ADD CONSTRAINT "course_difficulty_levels_course_id_fkey" FOREIGN KEY ("course_id") REFERENCES "courses"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- CreateIndex
+CREATE INDEX "classes_course_id_idx" ON "classes"("course_id");
+
+-- Seed default difficulty levels for each course (3 levels: Dễ, Trung bình, Khó)
+INSERT INTO "course_difficulty_levels" ("id", "course_id", "name", "sort_order", "is_active")
+SELECT
+    gen_random_uuid()::text,
+    c.id,
+    levels.name,
+    levels.sort_order,
+    true
+FROM "courses" c
+CROSS JOIN (VALUES ('Dễ', 0), ('Trung bình', 1), ('Khó', 2)) AS levels(name, sort_order);

--- a/apps/api/src/class/class-category.service.ts
+++ b/apps/api/src/class/class-category.service.ts
@@ -21,11 +21,16 @@ export class ClassCategoryService {
   }
 
   async create(dto: CreateClassCategoryDto) {
-    return this.prisma.classCategory.create({
-      data: {
-        name: dto.name,
-        sortOrder: dto.sort_order ?? 0,
-      },
+    // ponytail: dual-write — create Course in same transaction as ClassCategory
+    const sortOrder = dto.sort_order ?? 0;
+    return this.prisma.$transaction(async (tx) => {
+      const category = await tx.classCategory.create({
+        data: { name: dto.name, sortOrder },
+      });
+      await tx.course.create({
+        data: { id: category.id, name: dto.name, sortOrder },
+      });
+      return category;
     });
   }
 
@@ -37,13 +42,29 @@ export class ClassCategoryService {
       throw new NotFoundException('Không tìm thấy phân loại lớp.');
     }
 
-    return this.prisma.classCategory.update({
-      where: { id },
-      data: {
-        ...(dto.name !== undefined ? { name: dto.name } : {}),
-        ...(dto.sort_order !== undefined ? { sortOrder: dto.sort_order } : {}),
-        ...(dto.is_active !== undefined ? { isActive: dto.is_active } : {}),
-      },
+    // ponytail: dual-write — update Course in same transaction
+    const categoryData: Record<string, unknown> = {};
+    const courseData: Record<string, unknown> = {};
+    if (dto.name !== undefined) {
+      categoryData.name = dto.name;
+      courseData.name = dto.name;
+    }
+    if (dto.sort_order !== undefined) {
+      categoryData.sortOrder = dto.sort_order;
+      courseData.sortOrder = dto.sort_order;
+    }
+    if (dto.is_active !== undefined) {
+      categoryData.isActive = dto.is_active;
+      courseData.isActive = dto.is_active;
+    }
+
+    return this.prisma.$transaction(async (tx) => {
+      const category = await tx.classCategory.update({
+        where: { id },
+        data: categoryData,
+      });
+      await tx.course.update({ where: { id }, data: courseData });
+      return category;
     });
   }
 
@@ -64,7 +85,11 @@ export class ClassCategoryService {
       );
     }
 
-    await this.prisma.classCategory.delete({ where: { id } });
+    // ponytail: dual-write — delete Course in same transaction
+    await this.prisma.$transaction(async (tx) => {
+      await tx.classCategory.delete({ where: { id } });
+      await tx.course.delete({ where: { id } });
+    });
     return { success: true };
   }
 }

--- a/apps/api/src/class/class.service.ts
+++ b/apps/api/src/class/class.service.ts
@@ -1197,6 +1197,7 @@ export class ClassService {
           id: generateClassId(),
           name: data.name,
           classCategoryId,
+          courseId: classCategoryId, // ponytail: dual-write — courseId tracks classCategoryId
           status: data.status,
           maxStudents: data.max_students,
           allowancePerSessionPerStudent: data.allowance_per_session_per_student,
@@ -1557,8 +1558,10 @@ export class ClassService {
 
     const data: Prisma.ClassUncheckedUpdateInput = {};
     if (dto.name !== undefined) data.name = dto.name;
-    if (dto.class_category_id !== undefined)
+    if (dto.class_category_id !== undefined) {
       data.classCategoryId = dto.class_category_id;
+      data.courseId = dto.class_category_id; // ponytail: dual-write
+    }
     if (dto.status !== undefined) data.status = dto.status;
     if (dto.max_students !== undefined) data.maxStudents = dto.max_students;
     if (dto.allowance_per_session_per_student !== undefined) {

--- a/docs/Database Schema.md
+++ b/docs/Database Schema.md
@@ -34,6 +34,8 @@ Tài liệu này được tổng hợp trực tiếp từ Prisma schema tại `a
 
 - `classes`
 - `class_categories` (phân loại lớp, tuỳ chỉnh được qua CRUD `/class-categories`)
+- `courses` (khoá học — song song với `class_categories` trong giai đoạn expand; mỗi `ClassCategory` có đúng một `Course` cùng id)
+- `course_difficulty_levels` (mức độ khó tuỳ chỉnh theo từng khoá học)
 - `class_teachers`
 - `student_classes`
 - `sessions`
@@ -79,6 +81,9 @@ Tài liệu này được tổng hợp trực tiếp từ Prisma schema tại `a
 
 - **User ↔ StudentInfo / StaffInfo**: quan hệ 1-0/1 qua `student_info.user_id` và `staff_info.user_id` (mỗi hồ sơ học sinh/nhân sự gắn tối đa một user, và mỗi user có tối đa một hồ sơ của từng loại).
 - **Class ↔ StaffInfo**: N-N qua `class_teachers`.
+- **Class ↔ Course**: N-1 qua `classes.course_id` (dual-write đồng bộ `class_category_id`).
+- **Course ↔ ClassCategory**: 1-1 shared PK (giai đoạn expand).
+- **Course ↔ CourseDifficultyLevel**: 1-N.
 - **Class ↔ StudentInfo**: N-N qua `student_classes`.
 - **Session → Class**: N-1 (`sessions.class_id`).
 - **Session → StaffInfo (teacher)**: N-1 (`sessions.teacher_id`, `onDelete: Restrict`).
@@ -219,6 +224,7 @@ Tài liệu này được tổng hợp trực tiếp từ Prisma schema tại `a
 - **PK format:** `UNICL-[0-9a-f]{10}` — ví dụ `UNICL-1a2b3c4d5e`. Đây là **mã định danh hệ thống** ngắn cho lớp; migration `20260523110000_short_system_entity_ids` dùng `pgcrypto.gen_random_bytes(5)` để sinh ID mới cho dữ liệu hiện có, không cắt từ UUID cũ. Không còn dùng `@default(uuid())` trong Prisma cho PK này.
 - Trường nghiệp vụ chính:
   - `class_category_id` (FK → `class_categories.id`, `onDelete: Restrict`), `status` (`ClassStatus`). Migration `20260818090000_add_class_category` thay enum cố định `ClassType` (`vip|basic|advance|hardcore`) bằng bảng `class_categories` để admin tự thêm/sửa/ẩn/xoá phân loại lớp qua CRUD `/class-categories` (xem mục 4.4.3). Khi tạo lớp không truyền `class_category_id`, backend fallback về phân loại `isActive=true` có `sort_order` nhỏ nhất (không còn hardcode `code='basic'`).
+  - `course_id` (FK → `courses.id`, `onDelete: Restrict`): dual-write — luôn đồng bộ với `class_category_id` trong giai đoạn expand. Mọi ghi lớp ghi cả hai cột, hai cột không bao giờ lệch.
   - `status`: `running` = lớp đang vận hành; `ended` = lớp đã kết thúc. `POST /class/:id/end` chỉ cho phép khi mọi `sessions` của lớp có `teacher_payment_status = paid` (case-insensitive); nếu còn `unpaid`/`pending`/`deposit` backend trả `400`. Khi kết thúc lớp, backend xóa lịch cố định hiện tại, chuyển membership học sinh đang học và phân công gia sư đang mở sang `inactive`, đồng thời dọn buổi bù tương lai của lớp. Response `GET /class/:id` trả thêm `endClassEligibility` (`canEnd`, `sessionCount`, `unpaidSessionCount`, `blockReason`) để FE disable nút **Kết thúc lớp** và chặn chọn trạng thái **Đã kết thúc** trong popup thông tin lớp khi chưa đủ điều kiện. `PATCH /class/:id/basic-info` **không** được dùng để chuyển `running → ended` (trả `400`; phải dùng `POST /end`). Lịch sử session, attendance, ví và payroll đã phát sinh vẫn giữ nguyên.
   - `max_students`, `allowance_per_session_per_student`, `max_allowance_per_session`, `scale_amount`
   - `max_allowance_per_session` là nullable:
@@ -288,6 +294,21 @@ Tài liệu này được tổng hợp trực tiếp từ Prisma schema tại `a
   - `DELETE /class-categories/:id` — `400` nếu còn lớp đang dùng phân loại này (`classes.count > 0`); thông báo hướng dẫn chuyển lớp sang phân loại khác hoặc set `is_active=false` thay vì xoá cứng.
 - Seed dữ liệu ban đầu gồm các mã cũ (`vip`, `basic`, `advance`, `hardcore`) cộng 3 mã mới: `thpt_basic` (THPT BASIC), `thpt_advanced` (THPT ADVANCED), `thpt_luyen_de` (THPT Luyện Đề).
 - Khi tạo lớp không truyền `class_category_id`, `ClassService.resolveDefaultClassCategoryId` fallback về phân loại `is_active=true` có `sort_order` nhỏ nhất (tie-break theo `name`) — không còn hardcode `code='basic'` để tránh vỡ khi admin đổi/xoá phân loại mặc định cũ.
+- **Dual-write với `courses`:** `ClassCategoryService` create/update/delete luôn thực hiện cùng thao tác trên `courses` trong cùng transaction, giữ id và các field name/sortOrder/isActive đồng bộ.
+
+### 4.4.0-course `courses` (Khoá học)
+
+- Song song với `class_categories` trong giai đoạn expand (migration `20260905100000`). Mỗi `ClassCategory` có đúng một `Course` cùng id.
+- Cột: `id` (PK, cùng giá trị với `class_categories.id`), `name`, `sort_order`, `is_active`, `default_duration_days` (nullable — `null` = vô hạn), `created_at`, `updated_at`.
+- Quan hệ: `class_categories` (1-1, shared PK), `classes` (1-N, `classes.course_id` FK `onDelete: Restrict`), `course_difficulty_levels` (1-N).
+- Hành vi API:暂 chưa có endpoint riêng — CRUD đi qua `/class-categories` (dual-write). Ticket contract sẽ tách API Course độc lập.
+
+### 4.4.0-diff `course_difficulty_levels` (Mức độ khó theo Khoá học)
+
+- Mỗi Khoá học tự định nghĩa thang độ khó riêng (tên + thứ tự + bật/tắt). Câu hỏi trong Ngân hàng câu hỏi gắn một mức khó.
+- Cột: `id` (PK), `course_id` (FK → `courses.id`, `onDelete: Cascade`), `name`, `sort_order`, `is_active`.
+- Constraint: `UNIQUE (course_id, name)`.
+- Seed mặc định 3 mức cho mỗi khoá: Dễ (0), Trung bình (1), Khó (2).
 
 ### 4.4.0 `student_classes` (Class ↔ StudentInfo)
 


### PR DESCRIPTION
## What

Expand phase of expand–contract: add `courses` table alongside `class_categories`, with `course_id` on `classes`.

## Changes

- **Prisma schema:** added `Course`, `CourseDifficultyLevel` models; added `courseId` FK to `Class`
- **Migration:** creates `courses` (backfilled from `class_categories`), `course_difficulty_levels` (3 defaults per course), adds + backfills `course_id` on `classes`
- **Dual-write (ClassCategoryService):** create/update/delete on `class_categories` now also writes `courses` in same transaction
- **Dual-write (ClassService):** `createClass` and `updateClassBasicInfo` write both `classCategoryId` and `courseId`
- **Docs:** updated `docs/Database Schema.md`

## Acceptance Criteria

- [x] `Course` has `name`, `sortOrder`, `isActive`, `defaultDurationDays` (nullable), `difficultyLevels`
- [x] Each `ClassCategory` has exactly one `Course` same id (backfilled by migration)
- [x] Every `Class` has `courseId` matching `classCategoryId` (backfilled by migration)
- [x] Create/update class writes both columns; two columns never diverge
- [x] `ClassCategory` intact; all old endpoints keep existing behavior
- [x] CI green (tsc --noEmit passes), no screen changes

## Blocked by

None

## Notes

- Seed 3 difficulty levels per course: Dễ, Trung bình, Khó
- `defaultDurationDays` nullable — `null` means unlimited
- Next ticket (contract) will deprecate `class_category_id` and migrate API/FE to use `course_id` exclusively