### PR TITLE
feat(auth): Student single-device login (ticket #65)

### DIFF
--- a/apps/api/prisma/schema/auth.prisma
+++ b/apps/api/prisma/schema/auth.prisma
@@ -15,18 +15,20 @@ model UserDevice {
 }
 
 model LoginRequest {
-  id            String    @id @default(uuid())
-  userId        String    @map("user_id")
-  tokenHash     String    @unique @map("token_hash")
-  verified      Boolean   @default(false)
-  deviceInfo    Json?     @map("device_info")
-  ipAddress     String?   @map("ip_address")
-  expiresAt     DateTime  @map("expires_at") @db.Timestamptz(6)
-  createdAt     DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
-  user          User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  id                  String    @id @default(uuid())
+  userId              String    @map("user_id")
+  tokenHash           String    @unique @map("token_hash")
+  activateSecretHash  String?   @unique @map("activate_secret_hash")
+  verified            Boolean   @default(false)
+  deviceInfo          Json?     @map("device_info")
+  ipAddress           String?   @map("ip_address")
+  expiresAt           DateTime  @map("expires_at") @db.Timestamptz(6)
+  createdAt           DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
+  user                User      @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([userId])
   @@index([tokenHash])
+  @@index([activateSecretHash])
   @@index([expiresAt])
   @@map("login_requests")
 }

--- a/apps/api/prisma/schema/auth.prisma
+++ b/apps/api/prisma/schema/auth.prisma
@@ -1,0 +1,32 @@
+model UserDevice {
+  id            String    @id @default(uuid())
+  userId        String    @map("user_id")
+  tokenHash     String    @unique @map("token_hash")
+  deviceInfo    Json?     @map("device_info")
+  ipAddress     String?   @map("ip_address")
+  lastActiveAt  DateTime  @default(now()) @map("last_active_at") @db.Timestamptz(6)
+  createdAt     DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
+  user          User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+  @@index([tokenHash])
+  @@index([lastActiveAt])
+  @@map("user_devices")
+}
+
+model LoginRequest {
+  id            String    @id @default(uuid())
+  userId        String    @map("user_id")
+  tokenHash     String    @unique @map("token_hash")
+  verified      Boolean   @default(false)
+  deviceInfo    Json?     @map("device_info")
+  ipAddress     String?   @map("ip_address")
+  expiresAt     DateTime  @map("expires_at") @db.Timestamptz(6)
+  createdAt     DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
+  user          User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+  @@index([tokenHash])
+  @@index([expiresAt])
+  @@map("login_requests")
+}

--- a/apps/api/prisma/schema/migrations/20260906000000_add_activate_secret_hash/migration.sql
+++ b/apps/api/prisma/schema/migrations/20260906000000_add_activate_secret_hash/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "login_requests" ADD COLUMN "activate_secret_hash" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "login_requests_activate_secret_hash_key" ON "login_requests"("activate_secret_hash");
+
+-- CreateIndex
+CREATE INDEX "login_requests_activate_secret_hash_idx" ON "login_requests"("activate_secret_hash");

--- a/apps/api/prisma/schema/user.prisma
+++ b/apps/api/prisma/schema/user.prisma
@@ -30,6 +30,8 @@ model User {
   topicsUpdated                          Topic[]                          @relation("TopicUpdatedBy")
   staffInfo                              StaffInfo?
   studentInfo                             StudentInfo?
+  userDevices                            UserDevice[]
+  loginRequests                           LoginRequest[]
 
   @@index([email])
   @@index([accountHandle])

--- a/apps/api/src/auth/auth-identity-cache.service.spec.ts
+++ b/apps/api/src/auth/auth-identity-cache.service.spec.ts
@@ -129,4 +129,52 @@ describe('AuthIdentityCacheService', () => {
     expect(prisma.user.findUnique).toHaveBeenCalledTimes(2);
     expect(prisma.staffInfo.findUnique).toHaveBeenCalledTimes(2);
   });
+
+  describe('getHasActiveDevice', () => {
+    it('caches result and only calls hasActiveFn once on repeated calls', async () => {
+      const hasActiveFn = jest.fn().mockResolvedValue(true);
+
+      const result1 = await service.getHasActiveDevice('user-1', hasActiveFn);
+      const result2 = await service.getHasActiveDevice('user-1', hasActiveFn);
+
+      expect(result1).toBe(true);
+      expect(result2).toBe(true);
+      expect(hasActiveFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns false and caches it', async () => {
+      const hasActiveFn = jest.fn().mockResolvedValue(false);
+
+      const result = await service.getHasActiveDevice('user-1', hasActiveFn);
+
+      expect(result).toBe(false);
+      expect(hasActiveFn).toHaveBeenCalledTimes(1);
+
+      // Cached — second call does not re-invoke
+      const result2 = await service.getHasActiveDevice('user-1', hasActiveFn);
+      expect(result2).toBe(false);
+      expect(hasActiveFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('re-fetches after invalidateHasActiveDevice', async () => {
+      const hasActiveFn = jest.fn().mockResolvedValue(true);
+
+      await service.getHasActiveDevice('user-1', hasActiveFn);
+      expect(hasActiveFn).toHaveBeenCalledTimes(1);
+
+      service.invalidateHasActiveDevice('user-1');
+      await service.getHasActiveDevice('user-1', hasActiveFn);
+      expect(hasActiveFn).toHaveBeenCalledTimes(2);
+    });
+
+    it('expires after TTL', async () => {
+      const hasActiveFn = jest.fn().mockResolvedValue(true);
+
+      await service.getHasActiveDevice('user-1', hasActiveFn);
+      jest.advanceTimersByTime(5_001);
+      await service.getHasActiveDevice('user-1', hasActiveFn);
+
+      expect(hasActiveFn).toHaveBeenCalledTimes(2);
+    });
+  });
 });

--- a/apps/api/src/auth/auth-identity-cache.service.ts
+++ b/apps/api/src/auth/auth-identity-cache.service.ts
@@ -35,6 +35,10 @@ export class AuthIdentityCacheService {
     CacheEntry<CachedAuthIdentity | null>
   >();
   private readonly staffRolesCache = new Map<string, CacheEntry<StaffRole[]>>();
+  private readonly hasActiveDeviceCache = new Map<
+    string,
+    CacheEntry<boolean>
+  >();
 
   constructor(
     private readonly prisma: PrismaService,
@@ -144,6 +148,25 @@ export class AuthIdentityCacheService {
   invalidateUser(userId: string) {
     this.authIdentityCache.delete(userId);
     this.staffRolesCache.delete(userId);
+    this.hasActiveDeviceCache.delete(userId);
+  }
+
+  async getHasActiveDevice(
+    userId: string,
+    hasActiveFn: () => Promise<boolean>,
+  ): Promise<boolean> {
+    const cached = this.readFromCache(this.hasActiveDeviceCache, userId);
+    if (cached !== undefined) {
+      return cached;
+    }
+
+    const result = await hasActiveFn();
+    this.writeToCache(this.hasActiveDeviceCache, userId, result);
+    return result;
+  }
+
+  invalidateHasActiveDevice(userId: string) {
+    this.hasActiveDeviceCache.delete(userId);
   }
 
   private readFromCache<T>(

--- a/apps/api/src/auth/auth.controller.spec.ts
+++ b/apps/api/src/auth/auth.controller.spec.ts
@@ -2,6 +2,10 @@ jest.mock('./auth.service', () => ({
   AuthService: class AuthServiceMock {},
 }));
 
+jest.mock('./user-device.service', () => ({
+  UserDeviceService: class UserDeviceServiceMock {},
+}));
+
 import { ForbiddenException } from '@nestjs/common';
 import { UserRole } from '../../generated/enums';
 import { AuthController } from './auth.controller';
@@ -28,6 +32,7 @@ describe('AuthController', () => {
   const jwtService = {
     verify: jest.fn(),
   };
+  const userDeviceService = {} as never;
 
   let controller: AuthController;
   let response: {
@@ -51,6 +56,7 @@ describe('AuthController', () => {
       authService as never,
       configService as never,
       jwtService as never,
+      userDeviceService,
     );
     response = {
       cookie: jest.fn(),

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -612,10 +612,7 @@ export class AuthController {
     description: 'Student already has an active device.',
   })
   @ApiResponse({ status: 429, description: 'Too many requests.' })
-  async studentLogin(
-    @Body() body: UserAuthDto,
-    @Req() req: Request,
-  ) {
+  async studentLogin(@Body() body: UserAuthDto, @Req() req: Request) {
     const deviceInfo = {
       userAgent: req.headers['user-agent'],
       acceptLanguage: req.headers['accept-language'],
@@ -635,21 +632,29 @@ export class AuthController {
 
   @Public()
   @HttpCode(HttpStatus.OK)
-  @Get('student/login/:requestId/poll')
+  @Post('student/login/poll')
   @Throttle({ default: { limit: 30, ttl: 60000 } })
   @ApiOperation({
     summary: 'Poll student login verification',
     description:
       'Polls the status of a student login request. Returns verified: true when the magic link has been clicked.',
   })
-  @ApiParam({ name: 'requestId', description: 'Login request ID' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        requestId: { type: 'string' },
+      },
+      required: ['requestId'],
+    },
+  })
   @ApiResponse({
     status: 200,
     description: 'Returns verification status.',
   })
   @ApiResponse({ status: 404, description: 'Request not found.' })
-  async studentLoginPoll(@Param('requestId') requestId: string) {
-    return this.authService.studentLoginPoll(requestId);
+  async studentLoginPoll(@Body() body: { requestId: string }) {
+    return this.authService.studentLoginPoll(body.requestId);
   }
 
   @Public()
@@ -689,9 +694,10 @@ export class AuthController {
       type: 'object',
       properties: {
         requestId: { type: 'string' },
+        activateSecret: { type: 'string' },
         rememberMe: { type: 'boolean', default: false },
       },
-      required: ['requestId'],
+      required: ['requestId', 'activateSecret'],
     },
   })
   @ApiResponse({
@@ -699,12 +705,15 @@ export class AuthController {
     description: 'Device activated, tokens issued.',
   })
   @ApiResponse({ status: 400, description: 'Request not verified or expired.' })
+  @ApiResponse({ status: 401, description: 'Invalid activation secret.' })
   async studentActivate(
-    @Body() body: { requestId: string; rememberMe?: boolean },
+    @Body()
+    body: { requestId: string; activateSecret: string; rememberMe?: boolean },
     @Res({ passthrough: true }) res: Response,
   ) {
     const tokenPair = await this.authService.activateStudentDevice(
       body.requestId,
+      body.activateSecret,
       body.rememberMe ?? false,
     );
     this.setAuthCookies(res, tokenPair, body.rememberMe ?? false);

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -5,6 +5,7 @@ import {
   Get,
   HttpCode,
   HttpStatus,
+  Param,
   Post,
   Query,
   Req,
@@ -38,6 +39,7 @@ import {
   ApiBody,
   ApiCookieAuth,
   ApiOperation,
+  ApiParam,
   ApiQuery,
   ApiResponse,
   ApiTags,
@@ -47,6 +49,10 @@ import { JwtService } from '@nestjs/jwt';
 import type { RequestWithResolvedAuthContext } from './auth-request-context';
 import { PUBLIC_REGISTRATION_DISABLED_MESSAGE } from './constants';
 import { GoogleAuthExceptionFilter } from './filters/google-auth.exception-filter';
+import { UserDeviceService } from './user-device.service';
+import { Roles } from './decorators/roles.decorator';
+import { RolesGuard } from './guards/roles.guard';
+import { StudentDeviceGuard } from './guards/student-device.guard';
 
 const ONE_MINUTE_IN_MS = 60_000;
 const THIRTY_MINUTES_IN_MS = 30 * ONE_MINUTE_IN_MS;
@@ -80,6 +86,7 @@ export class AuthController {
     private readonly authService: AuthService,
     private readonly configService: ConfigService,
     private readonly jwtService: JwtService,
+    private readonly userDeviceService: UserDeviceService,
   ) {}
 
   private getGuestProfile() {
@@ -249,7 +256,7 @@ export class AuthController {
   }
 
   @Public()
-  @UseGuards(JwtRefreshGuard)
+  @UseGuards(JwtRefreshGuard, StudentDeviceGuard)
   @HttpCode(HttpStatus.OK)
   @Post('refresh')
   @Throttle({ default: { limit: 120, ttl: ONE_MINUTE_IN_MS } })
@@ -579,6 +586,172 @@ export class AuthController {
   @UseFilters(GoogleAuthExceptionFilter)
   @UseGuards(AuthGuard('google'))
   async googleAuth() {}
+
+  // ─── Student single-device login ─────────────────────────────────────
+
+  @Public()
+  @HttpCode(HttpStatus.OK)
+  @Post('student/login')
+  @Throttle({ default: { limit: 5, ttl: 60000 } })
+  @ApiOperation({
+    summary: 'Initiate student login',
+    description:
+      'Validates credentials and sends a magic link to the student email. Returns a requestId for polling.',
+  })
+  @ApiBody({
+    type: UserAuthDto,
+    description: 'accountHandle, password, and optional rememberMe',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Login request created, verification email sent.',
+  })
+  @ApiResponse({ status: 401, description: 'Invalid credentials.' })
+  @ApiResponse({
+    status: 409,
+    description: 'Student already has an active device.',
+  })
+  @ApiResponse({ status: 429, description: 'Too many requests.' })
+  async studentLogin(
+    @Body() body: UserAuthDto,
+    @Req() req: Request,
+  ) {
+    const deviceInfo = {
+      userAgent: req.headers['user-agent'],
+      acceptLanguage: req.headers['accept-language'],
+    };
+    const ipAddress =
+      (req.headers['x-forwarded-for'] as string)?.split(',')[0]?.trim() ||
+      req.socket.remoteAddress ||
+      undefined;
+
+    return this.authService.studentLoginInit(
+      body.accountHandle,
+      body.password,
+      deviceInfo,
+      ipAddress,
+    );
+  }
+
+  @Public()
+  @HttpCode(HttpStatus.OK)
+  @Get('student/login/:requestId/poll')
+  @Throttle({ default: { limit: 30, ttl: 60000 } })
+  @ApiOperation({
+    summary: 'Poll student login verification',
+    description:
+      'Polls the status of a student login request. Returns verified: true when the magic link has been clicked.',
+  })
+  @ApiParam({ name: 'requestId', description: 'Login request ID' })
+  @ApiResponse({
+    status: 200,
+    description: 'Returns verification status.',
+  })
+  @ApiResponse({ status: 404, description: 'Request not found.' })
+  async studentLoginPoll(@Param('requestId') requestId: string) {
+    return this.authService.studentLoginPoll(requestId);
+  }
+
+  @Public()
+  @HttpCode(HttpStatus.OK)
+  @Get('verify-login')
+  @Throttle({ default: { limit: 30, ttl: 60000 } })
+  @ApiOperation({
+    summary: 'Verify login magic link',
+    description:
+      'Marks a login request as verified when the student clicks the magic link from email.',
+  })
+  @ApiQuery({
+    name: 'token',
+    required: true,
+    description: 'Login verification token from email',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Login request verified.',
+  })
+  @ApiResponse({ status: 400, description: 'Invalid or expired token.' })
+  async verifyLogin(@Query('token') token: string) {
+    return this.authService.verifyLoginMagicLink(token);
+  }
+
+  @Public()
+  @HttpCode(HttpStatus.OK)
+  @Post('student/activate')
+  @Throttle({ default: { limit: 10, ttl: 60000 } })
+  @ApiOperation({
+    summary: 'Activate student device',
+    description:
+      'Creates a device record and issues tokens after login request is verified.',
+  })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        requestId: { type: 'string' },
+        rememberMe: { type: 'boolean', default: false },
+      },
+      required: ['requestId'],
+    },
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Device activated, tokens issued.',
+  })
+  @ApiResponse({ status: 400, description: 'Request not verified or expired.' })
+  async studentActivate(
+    @Body() body: { requestId: string; rememberMe?: boolean },
+    @Res({ passthrough: true }) res: Response,
+  ) {
+    const tokenPair = await this.authService.activateStudentDevice(
+      body.requestId,
+      body.rememberMe ?? false,
+    );
+    this.setAuthCookies(res, tokenPair, body.rememberMe ?? false);
+    return { message: 'Đăng nhập thành công' };
+  }
+
+  @Post('student/logout')
+  @HttpCode(HttpStatus.OK)
+  @ApiCookieAuth('access_token')
+  @ApiOperation({
+    summary: 'Student self-logout',
+    description: 'Removes the current device and invalidates the session.',
+  })
+  @ApiResponse({ status: 200, description: 'Logged out successfully.' })
+  async studentLogout(
+    @Req() req: RequestWithResolvedAuthContext,
+    @Res({ passthrough: true }) res: Response,
+  ) {
+    const userId = await this.getAuthenticatedUserIdFromCookies(req);
+    await this.authService.studentSelfLogout(userId);
+
+    const authCookieOptions = this.getAuthCookieOptions();
+    res.clearCookie('access_token', authCookieOptions);
+    res.clearCookie('refresh_token', authCookieOptions);
+    return { message: 'Đã đăng xuất' };
+  }
+
+  @Post('admin/students/:id/force-logout')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(AuthGuard('jwt'), RolesGuard)
+  @Roles(UserRole.admin, UserRole.staff)
+  @ApiCookieAuth('access_token')
+  @ApiOperation({
+    summary: 'Force logout student',
+    description:
+      'Admin or staff force-logouts a student, removing all active devices.',
+  })
+  @ApiParam({ name: 'id', description: 'Student user ID' })
+  @ApiResponse({ status: 200, description: 'Student force-logged out.' })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions.' })
+  @ApiResponse({ status: 404, description: 'Student not found.' })
+  async forceLogoutStudent(
+    @Param('id') studentId: string,
+    @CurrentUser() actor: JwtPayload,
+  ) {
+    return this.authService.forceLogoutStudent(studentId, actor.id);
+  }
 
   @Public()
   @Get('google/callback')

--- a/apps/api/src/auth/auth.module.ts
+++ b/apps/api/src/auth/auth.module.ts
@@ -14,6 +14,7 @@ import { GoogleStrategy } from './strategies/google-oauth.strategy';
 import { AuthAccessService } from './auth-access.service';
 import { GoogleAuthExceptionFilter } from './filters/google-auth.exception-filter';
 import { ApiKeyGuard } from './guards/api-key.guard';
+import { UserDeviceService } from './user-device.service';
 
 @Module({
   imports: [
@@ -41,12 +42,14 @@ import { ApiKeyGuard } from './guards/api-key.guard';
     GoogleStrategy,
     GoogleAuthExceptionFilter,
     ApiKeyGuard,
+    UserDeviceService,
   ],
   exports: [
     AuthService,
     AuthAccessService,
     AuthIdentityCacheService,
     ApiKeyGuard,
+    UserDeviceService,
   ],
 })
 export class AuthModule {}

--- a/apps/api/src/auth/auth.service.spec.ts
+++ b/apps/api/src/auth/auth.service.spec.ts
@@ -778,9 +778,13 @@ describe('AuthService', () => {
 
     beforeEach(() => {
       userDeviceService.hashToken = jest.fn().mockReturnValue('hashed-secret');
-      userDeviceService.generateDeviceToken = jest.fn().mockReturnValue('device-token');
+      userDeviceService.generateDeviceToken = jest
+        .fn()
+        .mockReturnValue('device-token');
       userDeviceService.createDevice = jest.fn().mockResolvedValue({});
-      userDeviceService.removeAllDevicesForUser = jest.fn().mockResolvedValue({});
+      userDeviceService.removeAllDevicesForUser = jest
+        .fn()
+        .mockResolvedValue({});
       authIdentityCacheService.invalidateHasActiveDevice = jest.fn();
       jwtService.signAsync = jest.fn().mockResolvedValue('jwt-token');
     });
@@ -813,7 +817,9 @@ describe('AuthService', () => {
       expect(userDeviceService.createDevice).toHaveBeenCalledWith(
         expect.objectContaining({ userId: 'student-1' }),
       );
-      expect(authIdentityCacheService.invalidateHasActiveDevice).toHaveBeenCalledWith('student-1');
+      expect(
+        authIdentityCacheService.invalidateHasActiveDevice,
+      ).toHaveBeenCalledWith('student-1');
     });
 
     it('rejects when request is not verified', async () => {

--- a/apps/api/src/auth/auth.service.spec.ts
+++ b/apps/api/src/auth/auth.service.spec.ts
@@ -5,6 +5,9 @@ jest.mock('bcrypt', () => ({
   hash: jest.fn(),
   compare: jest.fn(),
 }));
+jest.mock('./user-device.service', () => ({
+  UserDeviceService: class UserDeviceServiceMock {},
+}));
 
 import * as bcrypt from 'bcrypt';
 import { ServiceUnavailableException } from '@nestjs/common';
@@ -30,8 +33,13 @@ describe('AuthService', () => {
   const mockPrisma = {
     user: {
       findUnique: jest.fn(),
+      findFirst: jest.fn(),
       upsert: jest.fn(),
       update: jest.fn(),
+    },
+    loginRequest: {
+      findUnique: jest.fn(),
+      delete: jest.fn().mockResolvedValue({}),
     },
     $transaction: jest.fn(),
   };
@@ -59,9 +67,21 @@ describe('AuthService', () => {
     getAuthIdentity: jest.fn(),
     getStaffRoles: jest.fn(),
     invalidateUser: jest.fn(),
+    invalidateHasActiveDevice: jest.fn(),
   };
   const authAccessService = {
     resolveForIdentity: jest.fn(),
+  };
+  const userDeviceService = {
+    hashToken: jest.fn(),
+    generateDeviceToken: jest.fn(),
+    generateActivateSecret: jest.fn(),
+    createDevice: jest.fn(),
+    removeAllDevicesForUser: jest.fn(),
+    hasActiveDevice: jest.fn(),
+    touchActiveDeviceForUser: jest.fn(),
+    cleanupExpiredLoginRequests: jest.fn(),
+    cleanupInactiveDevices: jest.fn(),
   };
 
   let service: AuthService;
@@ -120,6 +140,7 @@ describe('AuthService', () => {
       actionHistoryService as never,
       authIdentityCacheService as never,
       authAccessService as never,
+      userDeviceService as never,
     );
   });
 
@@ -736,5 +757,85 @@ describe('AuthService', () => {
     await expect(service.resendVerificationEmail('user-1')).rejects.toThrow(
       ServiceUnavailableException,
     );
+  });
+
+  describe('activateStudentDevice', () => {
+    const baseRequest = {
+      id: 'req-1',
+      userId: 'student-1',
+      verified: true,
+      expiresAt: new Date(Date.now() + 60_000),
+      activateSecretHash: null as string | null,
+      deviceInfo: { userAgent: 'test' },
+      ipAddress: '127.0.0.1',
+    };
+
+    const studentUser = {
+      id: 'student-1',
+      accountHandle: 'hocsinh1',
+      roleType: UserRole.student,
+    };
+
+    beforeEach(() => {
+      userDeviceService.hashToken = jest.fn().mockReturnValue('hashed-secret');
+      userDeviceService.generateDeviceToken = jest.fn().mockReturnValue('device-token');
+      userDeviceService.createDevice = jest.fn().mockResolvedValue({});
+      userDeviceService.removeAllDevicesForUser = jest.fn().mockResolvedValue({});
+      authIdentityCacheService.invalidateHasActiveDevice = jest.fn();
+      jwtService.signAsync = jest.fn().mockResolvedValue('jwt-token');
+    });
+
+    it('rejects when activateSecret hash does not match', async () => {
+      mockPrisma.loginRequest.findUnique.mockResolvedValueOnce({
+        ...baseRequest,
+        activateSecretHash: 'expected-hash',
+      });
+
+      await expect(
+        service.activateStudentDevice('req-1', 'wrong-secret'),
+      ).rejects.toThrow('Invalid activation secret');
+    });
+
+    it('issues tokens when activateSecret matches', async () => {
+      mockPrisma.loginRequest.findUnique.mockResolvedValueOnce({
+        ...baseRequest,
+        activateSecretHash: 'hashed-secret',
+      });
+      mockPrisma.user.findUnique.mockResolvedValueOnce(studentUser);
+
+      await expect(
+        service.activateStudentDevice('req-1', 'correct-secret'),
+      ).resolves.toMatchObject({
+        accessToken: 'jwt-token',
+        refreshToken: 'jwt-token',
+      });
+
+      expect(userDeviceService.createDevice).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: 'student-1' }),
+      );
+      expect(authIdentityCacheService.invalidateHasActiveDevice).toHaveBeenCalledWith('student-1');
+    });
+
+    it('rejects when request is not verified', async () => {
+      mockPrisma.loginRequest.findUnique.mockResolvedValueOnce({
+        ...baseRequest,
+        verified: false,
+      });
+
+      await expect(
+        service.activateStudentDevice('req-1', 'any-secret'),
+      ).rejects.toThrow('Login request not verified yet');
+    });
+
+    it('rejects when request is expired', async () => {
+      mockPrisma.loginRequest.findUnique.mockResolvedValueOnce({
+        ...baseRequest,
+        expiresAt: new Date(Date.now() - 1_000),
+      });
+
+      await expect(
+        service.activateStudentDevice('req-1', 'any-secret'),
+      ).rejects.toThrow('Login request expired');
+    });
   });
 });

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -28,6 +28,7 @@ import type { RequestWithResolvedAuthContext } from './auth-request-context';
 import { createSignedStorageUrl } from 'src/storage/supabase-storage';
 import { STAFF_DATA_CONSENT_VERSION } from './constants';
 import { UserDeviceService } from './user-device.service';
+import type { DeviceInfo } from './user-device.service';
 
 type JwtSignOptions = Parameters<JwtService['signAsync']>[1];
 type UserAuditClient = Prisma.TransactionClient | PrismaService;
@@ -238,6 +239,11 @@ export class AuthService {
 
     if (!user) {
       throw new UnauthorizedException('User not found');
+    }
+
+    // Touch device on refresh so 60-day inactivity rule works
+    if (user.roleType === UserRole.student) {
+      await this.userDeviceService.touchActiveDeviceForUser(user.id);
     }
 
     return this.generateTokenPairAndSave(
@@ -956,9 +962,9 @@ export class AuthService {
   async studentLoginInit(
     accountHandle: string,
     password: string,
-    deviceInfo?: Record<string, unknown>,
+    deviceInfo?: DeviceInfo,
     ipAddress?: string,
-  ): Promise<{ requestId: string; message: string }> {
+  ): Promise<{ requestId: string; activateSecret: string; message: string }> {
     const user = await this.prisma.user.findFirst({
       where: {
         OR: [{ accountHandle }, { email: accountHandle }],
@@ -1009,10 +1015,13 @@ export class AuthService {
     }
 
     // Create login request
-    const loginRequestToken = this.userDeviceService.generateLoginRequestToken();
+    const loginRequestToken =
+      this.userDeviceService.generateLoginRequestToken();
+    const activateSecret = this.userDeviceService.generateActivateSecret();
     const loginRequest = await this.userDeviceService.createLoginRequest({
       userId: user.id,
       token: loginRequestToken,
+      activateSecret,
       deviceInfo,
       ipAddress,
     });
@@ -1024,10 +1033,7 @@ export class AuthService {
     const verifyUrl = `${frontendUrl}/auth/verify-login?token=${encodeURIComponent(loginRequestToken)}`;
 
     try {
-      await this.mailService.sendLoginVerificationEmail(
-        user.email,
-        verifyUrl,
-      );
+      await this.mailService.sendLoginVerificationEmail(user.email, verifyUrl);
     } catch (error) {
       this.logger.error(
         `Failed to send login verification email to ${user.email}`,
@@ -1038,14 +1044,13 @@ export class AuthService {
 
     return {
       requestId: loginRequest.id,
+      activateSecret,
       message:
         'Đã gửi email xác minh. Vui lòng kiểm tra hộp thư và bấm liên kết để hoàn tất đăng nhập.',
     };
   }
 
-  async studentLoginPoll(
-    requestId: string,
-  ): Promise<{ verified: boolean; requestId: string }> {
+  async studentLoginPoll(requestId: string): Promise<{ verified: boolean }> {
     const request = await this.prisma.loginRequest.findUnique({
       where: { id: requestId },
       select: { verified: true, expiresAt: true },
@@ -1059,11 +1064,12 @@ export class AuthService {
       throw new BadRequestException('Login request expired');
     }
 
-    return { verified: request.verified, requestId };
+    return { verified: request.verified };
   }
 
   async activateStudentDevice(
     requestId: string,
+    activateSecret: string,
     rememberMe = false,
   ): Promise<TokenPair> {
     const request = await this.prisma.loginRequest.findUnique({
@@ -1073,6 +1079,7 @@ export class AuthService {
         userId: true,
         verified: true,
         expiresAt: true,
+        activateSecretHash: true,
         deviceInfo: true,
         ipAddress: true,
       },
@@ -1090,6 +1097,15 @@ export class AuthService {
       throw new BadRequestException('Login request expired');
     }
 
+    // Verify activate secret
+    if (
+      !request.activateSecretHash ||
+      this.userDeviceService.hashToken(activateSecret) !==
+        request.activateSecretHash
+    ) {
+      throw new UnauthorizedException('Invalid activation secret');
+    }
+
     // Remove any existing devices for this student (single-device rule)
     await this.userDeviceService.removeAllDevicesForUser(request.userId);
 
@@ -1098,7 +1114,7 @@ export class AuthService {
     await this.userDeviceService.createDevice({
       userId: request.userId,
       token: deviceToken,
-      deviceInfo: request.deviceInfo as Record<string, unknown> | undefined,
+      deviceInfo: request.deviceInfo as DeviceInfo | undefined,
       ipAddress: request.ipAddress ?? undefined,
     });
 
@@ -1113,7 +1129,9 @@ export class AuthService {
     });
 
     if (!user) {
-      throw new InternalServerErrorException('User not found after verification');
+      throw new InternalServerErrorException(
+        'User not found after verification',
+      );
     }
 
     // Generate JWT tokens
@@ -1206,17 +1224,9 @@ export class AuthService {
     return { message: 'Đã buộc đăng xuất học sinh' };
   }
 
-  async studentSelfLogout(
-    userId: string,
-    deviceTokenHash?: string,
-  ): Promise<{ message: string }> {
-    if (deviceTokenHash) {
-      // Remove specific device
-      await this.userDeviceService.removeDevice(deviceTokenHash);
-    } else {
-      // Remove all devices
-      await this.userDeviceService.removeAllDevicesForUser(userId);
-    }
+  async studentSelfLogout(userId: string): Promise<{ message: string }> {
+    // Remove all devices
+    await this.userDeviceService.removeAllDevicesForUser(userId);
 
     // Also invalidate refresh token
     await this.prisma.user.update({

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -1,8 +1,11 @@
 import {
   BadRequestException,
+  ConflictException,
   HttpException,
   Injectable,
   InternalServerErrorException,
+  Logger,
+  NotFoundException,
   UnauthorizedException,
 } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
@@ -24,6 +27,7 @@ import { AuthProfileDto, LoginResponseDto } from 'src/dtos/auth.dto';
 import type { RequestWithResolvedAuthContext } from './auth-request-context';
 import { createSignedStorageUrl } from 'src/storage/supabase-storage';
 import { STAFF_DATA_CONSENT_VERSION } from './constants';
+import { UserDeviceService } from './user-device.service';
 
 type JwtSignOptions = Parameters<JwtService['signAsync']>[1];
 type UserAuditClient = Prisma.TransactionClient | PrismaService;
@@ -80,6 +84,7 @@ export class AuthService {
     private readonly actionHistoryService: ActionHistoryService,
     private readonly authIdentityCacheService: AuthIdentityCacheService,
     private readonly authAccessService: AuthAccessService,
+    private readonly userDeviceService: UserDeviceService,
   ) {
     this.accessTokenOptions = {
       expiresIn: this.accessTokenExpiresIn,
@@ -945,4 +950,287 @@ export class AuthService {
       return null;
     }
   }
+
+  // ─── Student single-device login ─────────────────────────────────────
+
+  async studentLoginInit(
+    accountHandle: string,
+    password: string,
+    deviceInfo?: Record<string, unknown>,
+    ipAddress?: string,
+  ): Promise<{ requestId: string; message: string }> {
+    const user = await this.prisma.user.findFirst({
+      where: {
+        OR: [{ accountHandle }, { email: accountHandle }],
+      },
+      select: {
+        id: true,
+        email: true,
+        passwordHash: true,
+        roleType: true,
+        emailVerified: true,
+      },
+    });
+
+    if (!user || !user.passwordHash) {
+      throw new UnauthorizedException('Invalid credentials');
+    }
+
+    if (user.roleType !== UserRole.student) {
+      throw new BadRequestException(
+        'Student login flow is only for student accounts',
+      );
+    }
+
+    const isPasswordValid = await bcrypt.compare(password, user.passwordHash);
+    if (!isPasswordValid) {
+      throw new UnauthorizedException('Invalid credentials');
+    }
+
+    if (!user.emailVerified) {
+      throw new BadRequestException('Email not verified');
+    }
+
+    // Lazy cleanup: remove expired login requests and inactive devices
+    await Promise.all([
+      this.userDeviceService.cleanupExpiredLoginRequests(),
+      this.userDeviceService.cleanupInactiveDevices(),
+    ]);
+
+    // Check if student already has an active device
+    const hasActive = await this.userDeviceService.hasActiveDevice(user.id);
+    if (hasActive) {
+      throw new ConflictException({
+        statusCode: 409,
+        error: 'DEVICE_ACTIVE',
+        message:
+          'Tài khoản đang đăng nhập ở thiết bị khác. Vui lòng đăng xuất thiết bị cũ hoặc liên hệ quản trị viên.',
+      });
+    }
+
+    // Create login request
+    const loginRequestToken = this.userDeviceService.generateLoginRequestToken();
+    const loginRequest = await this.userDeviceService.createLoginRequest({
+      userId: user.id,
+      token: loginRequestToken,
+      deviceInfo,
+      ipAddress,
+    });
+
+    // Send magic link email
+    const frontendUrl = this.configService
+      .get<string>('FRONTEND_URL')
+      ?.replace(/\/$/, '');
+    const verifyUrl = `${frontendUrl}/auth/verify-login?token=${encodeURIComponent(loginRequestToken)}`;
+
+    try {
+      await this.mailService.sendLoginVerificationEmail(
+        user.email,
+        verifyUrl,
+      );
+    } catch (error) {
+      this.logger.error(
+        `Failed to send login verification email to ${user.email}`,
+        error instanceof Error ? error.stack : error,
+      );
+      // Don't fail the request — email sending is best-effort
+    }
+
+    return {
+      requestId: loginRequest.id,
+      message:
+        'Đã gửi email xác minh. Vui lòng kiểm tra hộp thư và bấm liên kết để hoàn tất đăng nhập.',
+    };
+  }
+
+  async studentLoginPoll(
+    requestId: string,
+  ): Promise<{ verified: boolean; requestId: string }> {
+    const request = await this.prisma.loginRequest.findUnique({
+      where: { id: requestId },
+      select: { verified: true, expiresAt: true },
+    });
+
+    if (!request) {
+      throw new NotFoundException('Login request not found');
+    }
+
+    if (new Date() > request.expiresAt) {
+      throw new BadRequestException('Login request expired');
+    }
+
+    return { verified: request.verified, requestId };
+  }
+
+  async activateStudentDevice(
+    requestId: string,
+    rememberMe = false,
+  ): Promise<TokenPair> {
+    const request = await this.prisma.loginRequest.findUnique({
+      where: { id: requestId },
+      select: {
+        id: true,
+        userId: true,
+        verified: true,
+        expiresAt: true,
+        deviceInfo: true,
+        ipAddress: true,
+      },
+    });
+
+    if (!request) {
+      throw new NotFoundException('Login request not found');
+    }
+
+    if (!request.verified) {
+      throw new BadRequestException('Login request not verified yet');
+    }
+
+    if (new Date() > request.expiresAt) {
+      throw new BadRequestException('Login request expired');
+    }
+
+    // Remove any existing devices for this student (single-device rule)
+    await this.userDeviceService.removeAllDevicesForUser(request.userId);
+
+    // Create the device
+    const deviceToken = this.userDeviceService.generateDeviceToken();
+    await this.userDeviceService.createDevice({
+      userId: request.userId,
+      token: deviceToken,
+      deviceInfo: request.deviceInfo as Record<string, unknown> | undefined,
+      ipAddress: request.ipAddress ?? undefined,
+    });
+
+    // Get user info for token generation
+    const user = await this.prisma.user.findUnique({
+      where: { id: request.userId },
+      select: {
+        id: true,
+        accountHandle: true,
+        roleType: true,
+      },
+    });
+
+    if (!user) {
+      throw new InternalServerErrorException('User not found after verification');
+    }
+
+    // Generate JWT tokens
+    const tokenPair = await this.generateTokenPairAndSave(
+      user.id,
+      user.accountHandle,
+      user.roleType,
+      rememberMe,
+    );
+
+    // Cleanup the login request
+    await this.prisma.loginRequest.delete({ where: { id: request.id } });
+
+    return tokenPair;
+  }
+
+  async verifyLoginMagicLink(
+    token: string,
+  ): Promise<{ message: string; verified: boolean }> {
+    if (!token) {
+      throw new BadRequestException('Token is required');
+    }
+
+    const tokenHash = this.userDeviceService.hashToken(token);
+    const request =
+      await this.userDeviceService.findLoginRequestByTokenHash(tokenHash);
+
+    if (!request) {
+      throw new BadRequestException('Invalid or expired login link');
+    }
+
+    if (new Date() > request.expiresAt) {
+      throw new BadRequestException('Login link expired');
+    }
+
+    if (request.verified) {
+      return { message: 'Liên kết đã được xác minh', verified: true };
+    }
+
+    await this.userDeviceService.verifyLoginRequest(tokenHash);
+    return { message: 'Đã xác minh thành công', verified: true };
+  }
+
+  async forceLogoutStudent(
+    studentId: string,
+    actorId: string,
+  ): Promise<{ message: string }> {
+    const student = await this.prisma.user.findUnique({
+      where: { id: studentId },
+      select: { id: true, email: true, roleType: true },
+    });
+
+    if (!student) {
+      throw new NotFoundException('Student not found');
+    }
+
+    if (student.roleType !== UserRole.student) {
+      throw new BadRequestException('Target must be a student account');
+    }
+
+    const actor = await this.prisma.user.findUnique({
+      where: { id: actorId },
+      select: { id: true, email: true, roleType: true },
+    });
+
+    if (!actor) {
+      throw new UnauthorizedException('Actor not found');
+    }
+
+    // Remove all devices
+    await this.userDeviceService.removeAllDevicesForUser(studentId);
+
+    // Invalidate refresh token
+    await this.prisma.user.update({
+      where: { id: studentId },
+      data: { refreshToken: null },
+    });
+    this.invalidateAuthIdentityCache(studentId);
+
+    // Audit trail
+    await this.actionHistoryService.recordUpdate(this.prisma, {
+      actor: this.buildUserActor(actor),
+      entityType: 'user_device',
+      entityId: studentId,
+      description: `Buộc đăng xuất học sinh ${student.email}`,
+      beforeValue: { studentId },
+      afterValue: { forceLogout: true },
+    });
+
+    return { message: 'Đã buộc đăng xuất học sinh' };
+  }
+
+  async studentSelfLogout(
+    userId: string,
+    deviceTokenHash?: string,
+  ): Promise<{ message: string }> {
+    if (deviceTokenHash) {
+      // Remove specific device
+      await this.userDeviceService.removeDevice(deviceTokenHash);
+    } else {
+      // Remove all devices
+      await this.userDeviceService.removeAllDevicesForUser(userId);
+    }
+
+    // Also invalidate refresh token
+    await this.prisma.user.update({
+      where: { id: userId },
+      data: { refreshToken: null },
+    });
+    this.invalidateAuthIdentityCache(userId);
+
+    return { message: 'Đã đăng xuất' };
+  }
+
+  async touchStudentDevice(deviceTokenHash: string) {
+    await this.userDeviceService.touchDevice(deviceTokenHash);
+  }
+
+  private readonly logger = new Logger(AuthService.name);
 }

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -982,19 +982,27 @@ export class AuthService {
       throw new UnauthorizedException('Invalid credentials');
     }
 
-    if (user.roleType !== UserRole.student) {
-      throw new BadRequestException(
-        'Student login flow is only for student accounts',
-      );
-    }
-
+    // Verify password before revealing account type (prevents enumeration)
     const isPasswordValid = await bcrypt.compare(password, user.passwordHash);
     if (!isPasswordValid) {
       throw new UnauthorizedException('Invalid credentials');
     }
 
+    if (user.roleType !== UserRole.student) {
+      throw new BadRequestException({
+        statusCode: 400,
+        error: 'NOT_STUDENT_ACCOUNT',
+        message: 'Tài khoản này không phải tài khoản học sinh.',
+      });
+    }
+
     if (!user.emailVerified) {
-      throw new BadRequestException('Email not verified');
+      throw new BadRequestException({
+        statusCode: 400,
+        error: 'EMAIL_NOT_VERIFIED',
+        message:
+          'Email chưa được xác minh. Vui lòng xác minh email trước khi đăng nhập.',
+      });
     }
 
     // Lazy cleanup: remove expired login requests and inactive devices
@@ -1108,6 +1116,7 @@ export class AuthService {
 
     // Remove any existing devices for this student (single-device rule)
     await this.userDeviceService.removeAllDevicesForUser(request.userId);
+    this.authIdentityCacheService.invalidateHasActiveDevice(request.userId);
 
     // Create the device
     const deviceToken = this.userDeviceService.generateDeviceToken();
@@ -1203,6 +1212,7 @@ export class AuthService {
 
     // Remove all devices
     await this.userDeviceService.removeAllDevicesForUser(studentId);
+    this.authIdentityCacheService.invalidateHasActiveDevice(studentId);
 
     // Invalidate refresh token
     await this.prisma.user.update({
@@ -1227,6 +1237,7 @@ export class AuthService {
   async studentSelfLogout(userId: string): Promise<{ message: string }> {
     // Remove all devices
     await this.userDeviceService.removeAllDevicesForUser(userId);
+    this.authIdentityCacheService.invalidateHasActiveDevice(userId);
 
     // Also invalidate refresh token
     await this.prisma.user.update({

--- a/apps/api/src/auth/guards/student-device.guard.ts
+++ b/apps/api/src/auth/guards/student-device.guard.ts
@@ -1,0 +1,63 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { JwtService } from '@nestjs/jwt';
+import type { Request } from 'express';
+import { UserRole } from 'generated/enums';
+import { PrismaService } from '../../prisma/prisma.service';
+import { UserDeviceService } from '../user-device.service';
+
+const DEVICE_INACTIVITY_DAYS = 60;
+
+@Injectable()
+export class StudentDeviceGuard implements CanActivate {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly jwtService: JwtService,
+    private readonly configService: ConfigService,
+    private readonly userDeviceService: UserDeviceService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest<Request>();
+    const refreshToken = request.cookies?.refresh_token as string | undefined;
+
+    if (!refreshToken) {
+      return true; // No token — let the JWT guard handle unauthorized
+    }
+
+    let payload: { id: string; roleType: UserRole };
+    try {
+      payload = await this.jwtService.verifyAsync<{ id: string; roleType: UserRole }>(
+        refreshToken,
+        {
+          secret: this.configService.getOrThrow<string>('JWT_REFRESH_SECRET'),
+        },
+      );
+    } catch {
+      return true; // Invalid token — let the JWT guard handle it
+    }
+
+    // Only enforce device check for students
+    if (payload.roleType !== UserRole.student) {
+      return true;
+    }
+
+    // Check if student has at least one active device
+    const hasActive = await this.userDeviceService.hasActiveDevice(payload.id);
+    if (!hasActive) {
+      throw new UnauthorizedException({
+        statusCode: 401,
+        error: 'NO_ACTIVE_DEVICE',
+        message:
+          'Phiên đăng nhập đã hết hạn. Vui lòng đăng nhập lại.',
+      });
+    }
+
+    return true;
+  }
+}

--- a/apps/api/src/auth/guards/student-device.guard.ts
+++ b/apps/api/src/auth/guards/student-device.guard.ts
@@ -11,8 +11,6 @@ import { UserRole } from 'generated/enums';
 import { PrismaService } from '../../prisma/prisma.service';
 import { UserDeviceService } from '../user-device.service';
 
-const DEVICE_INACTIVITY_DAYS = 60;
-
 @Injectable()
 export class StudentDeviceGuard implements CanActivate {
   constructor(
@@ -32,12 +30,12 @@ export class StudentDeviceGuard implements CanActivate {
 
     let payload: { id: string; roleType: UserRole };
     try {
-      payload = await this.jwtService.verifyAsync<{ id: string; roleType: UserRole }>(
-        refreshToken,
-        {
-          secret: this.configService.getOrThrow<string>('JWT_REFRESH_SECRET'),
-        },
-      );
+      payload = await this.jwtService.verifyAsync<{
+        id: string;
+        roleType: UserRole;
+      }>(refreshToken, {
+        secret: this.configService.getOrThrow<string>('JWT_REFRESH_SECRET'),
+      });
     } catch {
       return true; // Invalid token — let the JWT guard handle it
     }
@@ -53,8 +51,7 @@ export class StudentDeviceGuard implements CanActivate {
       throw new UnauthorizedException({
         statusCode: 401,
         error: 'NO_ACTIVE_DEVICE',
-        message:
-          'Phiên đăng nhập đã hết hạn. Vui lòng đăng nhập lại.',
+        message: 'Phiên đăng nhập đã hết hạn. Vui lòng đăng nhập lại.',
       });
     }
 

--- a/apps/api/src/auth/strategies/jwt.strategy.spec.ts
+++ b/apps/api/src/auth/strategies/jwt.strategy.spec.ts
@@ -143,7 +143,9 @@ describe('JwtStrategy', () => {
     };
 
     it('rejects student with no active device', async () => {
-      authIdentityCacheService.getAuthIdentity.mockResolvedValue(studentIdentity);
+      authIdentityCacheService.getAuthIdentity.mockResolvedValue(
+        studentIdentity,
+      );
       authIdentityCacheService.getHasActiveDevice.mockResolvedValue(false);
 
       await expect(
@@ -157,7 +159,9 @@ describe('JwtStrategy', () => {
     });
 
     it('passes student with active device', async () => {
-      authIdentityCacheService.getAuthIdentity.mockResolvedValue(studentIdentity);
+      authIdentityCacheService.getAuthIdentity.mockResolvedValue(
+        studentIdentity,
+      );
       authIdentityCacheService.getHasActiveDevice.mockResolvedValue(true);
 
       await expect(
@@ -193,7 +197,9 @@ describe('JwtStrategy', () => {
         roleType: UserRole.staff,
       });
 
-      expect(authIdentityCacheService.getHasActiveDevice).not.toHaveBeenCalled();
+      expect(
+        authIdentityCacheService.getHasActiveDevice,
+      ).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/auth/strategies/jwt.strategy.spec.ts
+++ b/apps/api/src/auth/strategies/jwt.strategy.spec.ts
@@ -1,6 +1,9 @@
 jest.mock('src/prisma/prisma.service', () => ({
   PrismaService: class PrismaServiceMock {},
 }));
+jest.mock('../user-device.service', () => ({
+  UserDeviceService: class UserDeviceServiceMock {},
+}));
 
 import { UnauthorizedException } from '@nestjs/common';
 import { UserRole } from 'generated/enums';
@@ -13,7 +16,9 @@ describe('JwtStrategy', () => {
   };
   const authIdentityCacheService = {
     getAuthIdentity: jest.fn(),
+    getHasActiveDevice: jest.fn(),
   };
+  const userDeviceService = {} as never;
 
   let strategy: JwtStrategy;
 
@@ -22,6 +27,7 @@ describe('JwtStrategy', () => {
     strategy = new JwtStrategy(
       configService as never,
       authIdentityCacheService as never,
+      userDeviceService,
     );
   });
 
@@ -123,5 +129,71 @@ describe('JwtStrategy', () => {
         roleType: UserRole.staff,
       }),
     ).rejects.toThrow(UnauthorizedException);
+  });
+
+  describe('student device check', () => {
+    const studentIdentity = {
+      id: 'student-1',
+      email: 'student@example.com',
+      accountHandle: 'student-1',
+      roleType: UserRole.student,
+      status: 'active',
+      requiresPasswordSetup: false,
+      avatarPath: null,
+    };
+
+    it('rejects student with no active device', async () => {
+      authIdentityCacheService.getAuthIdentity.mockResolvedValue(studentIdentity);
+      authIdentityCacheService.getHasActiveDevice.mockResolvedValue(false);
+
+      await expect(
+        strategy.validate({} as RequestWithResolvedAuthContext, {
+          id: 'student-1',
+          email: '',
+          accountHandle: 'ignored',
+          roleType: UserRole.student,
+        }),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('passes student with active device', async () => {
+      authIdentityCacheService.getAuthIdentity.mockResolvedValue(studentIdentity);
+      authIdentityCacheService.getHasActiveDevice.mockResolvedValue(true);
+
+      await expect(
+        strategy.validate({} as RequestWithResolvedAuthContext, {
+          id: 'student-1',
+          email: '',
+          accountHandle: 'ignored',
+          roleType: UserRole.student,
+        }),
+      ).resolves.toEqual({
+        id: 'student-1',
+        email: 'student@example.com',
+        accountHandle: 'student-1',
+        roleType: UserRole.student,
+      });
+    });
+
+    it('skips device check for staff', async () => {
+      const staffIdentity = { ...studentIdentity, roleType: UserRole.staff };
+      authIdentityCacheService.getAuthIdentity.mockResolvedValue(staffIdentity);
+
+      await expect(
+        strategy.validate({} as RequestWithResolvedAuthContext, {
+          id: 'staff-1',
+          email: '',
+          accountHandle: 'ignored',
+          roleType: UserRole.staff,
+        }),
+      ).resolves.toEqual({
+        id: 'student-1',
+        email: 'student@example.com',
+        accountHandle: 'student-1',
+        roleType: UserRole.staff,
+      });
+
+      expect(authIdentityCacheService.getHasActiveDevice).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/api/src/auth/strategies/jwt.strategy.ts
+++ b/apps/api/src/auth/strategies/jwt.strategy.ts
@@ -6,6 +6,7 @@ import type { Request } from 'express';
 import { AuthIdentityCacheService } from '../auth-identity-cache.service';
 import type { RequestWithResolvedAuthContext } from '../auth-request-context';
 import { UserRole } from 'generated/enums';
+import { UserDeviceService } from '../user-device.service';
 
 const ACCESS_TOKEN_COOKIE = 'access_token';
 
@@ -22,6 +23,7 @@ export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
   constructor(
     private readonly configService: ConfigService,
     private readonly authIdentityCacheService: AuthIdentityCacheService,
+    private readonly userDeviceService: UserDeviceService,
   ) {
     super({
       jwtFromRequest: ExtractJwt.fromExtractors([
@@ -48,6 +50,19 @@ export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
     if (!user || user.status !== 'active') {
       throw new UnauthorizedException();
     }
+
+    // Students must have an active device (force-logout = no device = immediate rejection)
+    if (user.roleType === UserRole.student) {
+      const hasActive = await this.userDeviceService.hasActiveDevice(user.id);
+      if (!hasActive) {
+        throw new UnauthorizedException({
+          statusCode: 401,
+          error: 'NO_ACTIVE_DEVICE',
+          message: 'Phiên đăng nhập đã hết hạn. Vui lòng đăng nhập lại.',
+        });
+      }
+    }
+
     return {
       id: user.id,
       email: user.email,

--- a/apps/api/src/auth/strategies/jwt.strategy.ts
+++ b/apps/api/src/auth/strategies/jwt.strategy.ts
@@ -52,8 +52,12 @@ export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
     }
 
     // Students must have an active device (force-logout = no device = immediate rejection)
+    // Result cached in AuthIdentityCacheService to avoid DB round-trip per request
     if (user.roleType === UserRole.student) {
-      const hasActive = await this.userDeviceService.hasActiveDevice(user.id);
+      const hasActive = await this.authIdentityCacheService.getHasActiveDevice(
+        user.id,
+        () => this.userDeviceService.hasActiveDevice(user.id),
+      );
       if (!hasActive) {
         throw new UnauthorizedException({
           statusCode: 401,

--- a/apps/api/src/auth/user-device.service.ts
+++ b/apps/api/src/auth/user-device.service.ts
@@ -1,0 +1,159 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { createHash, randomBytes } from 'crypto';
+import type { Prisma } from '../../generated/client';
+import { PrismaService } from '../prisma/prisma.service';
+
+const DEVICE_TOKEN_BYTES = 32;
+const LOGIN_REQUEST_TOKEN_BYTES = 32;
+const LOGIN_REQUEST_EXPIRY_MS = 10 * 60 * 1000; // 10 minutes
+const DEVICE_INACTIVITY_DAYS = 60;
+
+@Injectable()
+export class UserDeviceService {
+  private readonly logger = new Logger(UserDeviceService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  hashToken(token: string): string {
+    return createHash('sha256').update(token).digest('hex');
+  }
+
+  generateDeviceToken(): string {
+    return randomBytes(DEVICE_TOKEN_BYTES).toString('hex');
+  }
+
+  generateLoginRequestToken(): string {
+    return randomBytes(LOGIN_REQUEST_TOKEN_BYTES).toString('hex');
+  }
+
+  async createDevice(params: {
+    userId: string;
+    token: string;
+    deviceInfo?: Record<string, unknown>;
+    ipAddress?: string;
+  }) {
+    const tokenHash = this.hashToken(params.token);
+    return this.prisma.userDevice.create({
+      data: {
+        userId: params.userId,
+        tokenHash,
+        deviceInfo: (params.deviceInfo as Prisma.InputJsonValue) ?? undefined,
+        ipAddress: params.ipAddress ?? undefined,
+        lastActiveAt: new Date(),
+      },
+    });
+  }
+
+  async findActiveDeviceByTokenHash(tokenHash: string) {
+    return this.prisma.userDevice.findUnique({
+      where: { tokenHash },
+    });
+  }
+
+  async hasActiveDevice(userId: string): Promise<boolean> {
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - DEVICE_INACTIVITY_DAYS);
+    const count = await this.prisma.userDevice.count({
+      where: {
+        userId,
+        lastActiveAt: { gte: cutoff },
+      },
+    });
+    return count > 0;
+  }
+
+  async touchDevice(tokenHash: string) {
+    return this.prisma.userDevice.updateMany({
+      where: { tokenHash },
+      data: { lastActiveAt: new Date() },
+    });
+  }
+
+  async removeDevice(tokenHash: string) {
+    return this.prisma.userDevice.deleteMany({
+      where: { tokenHash },
+    });
+  }
+
+  async removeAllDevicesForUser(userId: string) {
+    return this.prisma.userDevice.deleteMany({
+      where: { userId },
+    });
+  }
+
+  async removeDeviceById(deviceId: string, userId: string) {
+    return this.prisma.userDevice.deleteMany({
+      where: { id: deviceId, userId },
+    });
+  }
+
+  async listDevices(userId: string) {
+    return this.prisma.userDevice.findMany({
+      where: { userId },
+      orderBy: { lastActiveAt: 'desc' },
+      select: {
+        id: true,
+        deviceInfo: true,
+        ipAddress: true,
+        lastActiveAt: true,
+        createdAt: true,
+      },
+    });
+  }
+
+  // --- Login Requests ---
+
+  async createLoginRequest(params: {
+    userId: string;
+    token: string;
+    deviceInfo?: Record<string, unknown>;
+    ipAddress?: string;
+  }) {
+    const tokenHash = this.hashToken(params.token);
+    const expiresAt = new Date(Date.now() + LOGIN_REQUEST_EXPIRY_MS);
+    return this.prisma.loginRequest.create({
+      data: {
+        userId: params.userId,
+        tokenHash,
+        deviceInfo: (params.deviceInfo as Prisma.InputJsonValue) ?? undefined,
+        ipAddress: params.ipAddress ?? undefined,
+        expiresAt,
+      },
+    });
+  }
+
+  async findLoginRequestByTokenHash(tokenHash: string) {
+    return this.prisma.loginRequest.findUnique({
+      where: { tokenHash },
+    });
+  }
+
+  async verifyLoginRequest(tokenHash: string) {
+    return this.prisma.loginRequest.updateMany({
+      where: { tokenHash, verified: false },
+      data: { verified: true },
+    });
+  }
+
+  async cleanupExpiredLoginRequests() {
+    const result = await this.prisma.loginRequest.deleteMany({
+      where: { expiresAt: { lt: new Date() } },
+    });
+    if (result.count > 0) {
+      this.logger.log(`Cleaned up ${result.count} expired login requests`);
+    }
+    return result;
+  }
+
+  async cleanupInactiveDevices() {
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - DEVICE_INACTIVITY_DAYS);
+    const result = await this.prisma.userDevice.deleteMany({
+      where: { lastActiveAt: { lt: cutoff } },
+    });
+    if (result.count > 0) {
+      this.logger.log(`Cleaned up ${result.count} inactive devices`);
+    }
+    return result;
+  }
+}

--- a/apps/api/src/auth/user-device.service.ts
+++ b/apps/api/src/auth/user-device.service.ts
@@ -5,8 +5,14 @@ import { PrismaService } from '../prisma/prisma.service';
 
 const DEVICE_TOKEN_BYTES = 32;
 const LOGIN_REQUEST_TOKEN_BYTES = 32;
+const ACTIVATE_SECRET_BYTES = 32;
 const LOGIN_REQUEST_EXPIRY_MS = 10 * 60 * 1000; // 10 minutes
-const DEVICE_INACTIVITY_DAYS = 60;
+export const DEVICE_INACTIVITY_DAYS = 60;
+
+export interface DeviceInfo {
+  userAgent?: string;
+  acceptLanguage?: string;
+}
 
 @Injectable()
 export class UserDeviceService {
@@ -26,10 +32,14 @@ export class UserDeviceService {
     return randomBytes(LOGIN_REQUEST_TOKEN_BYTES).toString('hex');
   }
 
+  generateActivateSecret(): string {
+    return randomBytes(ACTIVATE_SECRET_BYTES).toString('hex');
+  }
+
   async createDevice(params: {
     userId: string;
     token: string;
-    deviceInfo?: Record<string, unknown>;
+    deviceInfo?: DeviceInfo;
     ipAddress?: string;
   }) {
     const tokenHash = this.hashToken(params.token);
@@ -65,6 +75,15 @@ export class UserDeviceService {
   async touchDevice(tokenHash: string) {
     return this.prisma.userDevice.updateMany({
       where: { tokenHash },
+      data: { lastActiveAt: new Date() },
+    });
+  }
+
+  async touchActiveDeviceForUser(userId: string) {
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - DEVICE_INACTIVITY_DAYS);
+    return this.prisma.userDevice.updateMany({
+      where: { userId, lastActiveAt: { gte: cutoff } },
       data: { lastActiveAt: new Date() },
     });
   }
@@ -106,15 +125,18 @@ export class UserDeviceService {
   async createLoginRequest(params: {
     userId: string;
     token: string;
-    deviceInfo?: Record<string, unknown>;
+    activateSecret: string;
+    deviceInfo?: DeviceInfo;
     ipAddress?: string;
   }) {
     const tokenHash = this.hashToken(params.token);
+    const activateSecretHash = this.hashToken(params.activateSecret);
     const expiresAt = new Date(Date.now() + LOGIN_REQUEST_EXPIRY_MS);
     return this.prisma.loginRequest.create({
       data: {
         userId: params.userId,
         tokenHash,
+        activateSecretHash,
         deviceInfo: (params.deviceInfo as Prisma.InputJsonValue) ?? undefined,
         ipAddress: params.ipAddress ?? undefined,
         expiresAt,
@@ -125,6 +147,12 @@ export class UserDeviceService {
   async findLoginRequestByTokenHash(tokenHash: string) {
     return this.prisma.loginRequest.findUnique({
       where: { tokenHash },
+    });
+  }
+
+  async findLoginRequestByActivateSecretHash(activateSecretHash: string) {
+    return this.prisma.loginRequest.findUnique({
+      where: { activateSecretHash },
     });
   }
 

--- a/apps/api/src/auth/user-device.service.ts
+++ b/apps/api/src/auth/user-device.service.ts
@@ -88,21 +88,9 @@ export class UserDeviceService {
     });
   }
 
-  async removeDevice(tokenHash: string) {
-    return this.prisma.userDevice.deleteMany({
-      where: { tokenHash },
-    });
-  }
-
   async removeAllDevicesForUser(userId: string) {
     return this.prisma.userDevice.deleteMany({
       where: { userId },
-    });
-  }
-
-  async removeDeviceById(deviceId: string, userId: string) {
-    return this.prisma.userDevice.deleteMany({
-      where: { id: deviceId, userId },
     });
   }
 

--- a/apps/api/src/mail/mail.service.ts
+++ b/apps/api/src/mail/mail.service.ts
@@ -235,6 +235,51 @@ export class MailService {
     });
   }
 
+  async sendLoginVerificationEmail(
+    email: string,
+    verifyUrl: string,
+  ): Promise<void> {
+    if (!this.transporter) {
+      throw new ServiceUnavailableException(
+        'Chưa cấu hình gửi email (SMTP). Vui lòng cấu hình SMTP trong .env hoặc liên hệ quản trị viên.',
+      );
+    }
+    const inlineLogo = this.buildAuthBrandLogoInlineImage();
+    const html = [
+      '<div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">',
+      inlineLogo.logoSrc
+        ? `<img src="${inlineLogo.logoSrc}" alt="Unicorns Edu" style="height: 40px; margin-bottom: 20px;" />`
+        : '',
+      '<h2 style="color: #1a1a2e;">Xác minh đăng nhập</h2>',
+      '<p>Bạn đã yêu cầu đăng nhập vào tài khoản Unicorns Edu.</p>',
+      '<p>Bấm nút bên dưới để xác minh đăng nhập:</p>',
+      `<a href="${verifyUrl}" style="display: inline-block; padding: 12px 24px; background-color: #6c63ff; color: white; text-decoration: none; border-radius: 6px; margin: 16px 0;">Xác minh đăng nhập</a>`,
+      '<p style="color: #666; font-size: 14px;">Liên kết hết hạn sau 10 phút.</p>',
+      '<p style="color: #666; font-size: 14px;">Nếu bạn không yêu cầu đăng nhập, hãy bỏ qua email này.</p>',
+      '</div>',
+    ].join('\n');
+    const text = [
+      'Xác minh đăng nhập Unicorns Edu',
+      '',
+      'Bạn đã yêu cầu đăng nhập vào tài khoản Unicorns Edu.',
+      `Liên kết xác minh (hiệu lực 10 phút):`,
+      verifyUrl,
+      '',
+      'Nếu bạn không yêu cầu đăng nhập, hãy bỏ qua email này.',
+    ].join('\n');
+
+    await this.sendMailOrThrow({
+      from: this.mailFrom,
+      to: email,
+      subject: '[Unicorns Edu] Xác minh đăng nhập',
+      text,
+      html,
+      ...(inlineLogo.attachments.length
+        ? { attachments: inlineLogo.attachments }
+        : {}),
+    });
+  }
+
   async sendStudentWalletDirectTopUpApprovalEmail(
     params: DirectTopUpApprovalEmailParams,
   ): Promise<void> {

--- a/apps/web/app/admin/students/[id]/page.tsx
+++ b/apps/web/app/admin/students/[id]/page.tsx
@@ -34,6 +34,7 @@ import * as studentApi from "@/lib/apis/student.api";
 import { pickAvatarUrl } from "@/lib/avatar";
 import { formatCurrency } from "@/lib/class.helpers";
 import { cn } from "@/lib/utils";
+import { forceLogoutStudent } from "@/lib/apis/auth.api";
 
 const STATUS_LABELS: Record<StudentStatus, string> = {
     active: "Đang học",
@@ -178,6 +179,24 @@ export default function AdminStudentDetailPage() {
         onSuccess: async () => {
             await queryClient.invalidateQueries({ queryKey: ["student", "detail", id] });
             toast.success("Đã cập nhật cài đặt gửi biên lai.");
+        },
+    });
+
+    const forceLogoutMutation = useMutation({
+        mutationFn: () => {
+            if (!student?.userId) {
+                throw new Error("Student userId not available");
+            }
+            return forceLogoutStudent(student.userId);
+        },
+        onSuccess: async () => {
+            toast.success("Đã buộc đăng xuất học sinh.");
+        },
+        onError: (err: unknown) => {
+            const msg =
+                (err as { response?: { data?: { message?: string } } })?.response?.data?.message ??
+                "Không thể buộc đăng xuất.";
+            toast.error(msg);
         },
     });
 
@@ -553,6 +572,24 @@ export default function AdminStudentDetailPage() {
                                             >
                                                 <svg className="size-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
                                                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 0 0-2 2v11a2 2 0 0 0 2 2h11a2 2 0 0 0 2-2v-5m-1.414-9.414a2 2 0 1 1 2.828 2.828L11.828 15H9v-2.828l8.586-8.586Z" />
+                                                </svg>
+                                            </button>
+                                        ) : null}
+                                        {canManageUsers && student.userId ? (
+                                            <button
+                                                type="button"
+                                                onClick={() => {
+                                                    if (confirm("Buộc đăng xuất học sinh này? Thiết bị hiện tại sẽ bị ngắt kết nối.")) {
+                                                        forceLogoutMutation.mutate();
+                                                    }
+                                                }}
+                                                disabled={forceLogoutMutation.isPending}
+                                                className="flex size-9 shrink-0 items-center justify-center rounded-full border border-border-default bg-bg-surface text-text-muted transition hover:bg-error/10 hover:text-error focus:outline-none focus-visible:ring-2 focus-visible:ring-border-focus focus-visible:ring-offset-2 focus-visible:ring-offset-bg-surface sm:size-8 disabled:opacity-50"
+                                                aria-label="Buộc đăng xuất học sinh"
+                                                title="Buộc đăng xuất"
+                                            >
+                                                <svg className="size-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
+                                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
                                                 </svg>
                                             </button>
                                         ) : null}

--- a/apps/web/app/auth/login/page.tsx
+++ b/apps/web/app/auth/login/page.tsx
@@ -2,13 +2,14 @@
 
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
-import { Suspense, useEffect, useState } from "react";
+import { Suspense, useEffect, useRef, useState } from "react";
 import type { SyntheticEvent } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { isAxiosError } from "axios";
 import { toast } from "sonner";
 import * as authApi from "@/lib/apis/auth.api";
 import type { LoginDto } from "@/dtos/Auth.dto";
+import { Role } from "@/dtos/Auth.dto";
 import { useAuth } from "@/context/AuthContext";
 import { BrandLogoLockup } from "@/components/BrandLogoLockup";
 import { AuthCardSkeleton } from "@/components/auth/AuthCardSkeleton";
@@ -59,6 +60,13 @@ function getLoginErrorToastMessage(error: unknown): string {
     return serverMsg ?? "Sai tài khoản hoặc mật khẩu.";
   }
 
+  if (status === 409) {
+    return (
+      serverMsg ??
+      "Tài khoản đang đăng nhập ở thiết bị khác. Vui lòng đăng xuất thiết bị cũ hoặc liên hệ quản trị viên."
+    );
+  }
+
   if (status === 429) {
     return (
       serverMsg ??
@@ -73,6 +81,8 @@ function hasAuthenticatedSession(user: { id: string; accountHandle: string }) {
   return Boolean(user.id && user.accountHandle);
 }
 
+type LoginStep = "form" | "pending" | "blocked";
+
 function LoginPageContent() {
   const { replace } = useRouter();
   const queryClient = useQueryClient();
@@ -84,6 +94,12 @@ function LoginPageContent() {
   const [isRedirecting, setIsRedirecting] = useState(false);
   const { setUser, user, isAuthReady } = useAuth();
 
+  // Student login flow state
+  const [loginStep, setLoginStep] = useState<LoginStep>("form");
+  const [requestId, setRequestId] = useState<string | null>(null);
+  const pollTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const [isActivating, setIsActivating] = useState(false);
+
   useEffect(() => {
     const err = getSearchParam("error");
     if (err === "registration_disabled") {
@@ -91,9 +107,22 @@ function LoginPageContent() {
       return;
     }
     if (err === "google_no_user") toast.error("Không lấy được thông tin từ Google. Vui lòng thử lại.");
+    if (err === "device_blocked") {
+      setLoginStep("blocked");
+    }
   }, [getSearchParam]);
 
-  const loginMutation = useMutation({
+  // Cleanup poll timer on unmount
+  useEffect(() => {
+    return () => {
+      if (pollTimerRef.current) {
+        clearInterval(pollTimerRef.current);
+      }
+    };
+  }, []);
+
+  // Staff/admin login (existing flow)
+  const staffLoginMutation = useMutation({
     mutationFn: async (body: LoginDto) => {
       const loginResponse = await authApi.logIn(body);
       return loginResponse;
@@ -125,8 +154,93 @@ function LoginPageContent() {
     },
   });
 
+  // Student login init
+  const studentLoginInitMutation = useMutation({
+    mutationFn: async (body: LoginDto) => {
+      return authApi.studentLoginInit(body);
+    },
+    onSuccess: (response) => {
+      setRequestId(response.requestId);
+      setLoginStep("pending");
+      toast.success("Đã gửi email xác minh. Vui lòng kiểm tra hộp thư.");
+      startPolling(response.requestId);
+    },
+    onError: (error) => {
+      if (isAxiosError(error) && error.response?.status === 409) {
+        setLoginStep("blocked");
+        return;
+      }
+      toast.error(getLoginErrorToastMessage(error));
+    },
+  });
+
+  // Student activate
+  const studentActivateMutation = useMutation({
+    mutationFn: async (reqId: string) => {
+      return authApi.studentActivate({
+        requestId: reqId,
+        rememberMe,
+      });
+    },
+    onSuccess: async () => {
+      setIsActivating(true);
+      toast.success("Đăng nhập thành công.");
+
+      // Fetch session after activation
+      const session = await authApi.getSession();
+      const fallbackSession = buildLoginFallbackSession({
+        id: session.id,
+        accountHandle: session.accountHandle,
+        roleType: session.roleType,
+        avatarUrl: session.avatarUrl,
+      });
+      setUser(fallbackSession);
+      queryClient.setQueryData(["auth", "session"], fallbackSession);
+
+      const { redirectHref } = await bootstrapPostLoginSession({
+        fallbackUser: fallbackSession,
+        queryClient,
+        setUser,
+        requestedNextPath: getSearchParam("next"),
+      });
+
+      replace(redirectHref);
+    },
+    onError: (error) => {
+      setIsActivating(false);
+      toast.error(getLoginErrorToastMessage(error));
+    },
+  });
+
+  const startPolling = (reqId: string) => {
+    if (pollTimerRef.current) {
+      clearInterval(pollTimerRef.current);
+    }
+    pollTimerRef.current = setInterval(async () => {
+      try {
+        const result = await authApi.studentLoginPoll(reqId);
+        if (result.verified) {
+          if (pollTimerRef.current) {
+            clearInterval(pollTimerRef.current);
+            pollTimerRef.current = null;
+          }
+          // Activate device
+          studentActivateMutation.mutate(reqId);
+        }
+      } catch {
+        if (pollTimerRef.current) {
+          clearInterval(pollTimerRef.current);
+          pollTimerRef.current = null;
+        }
+        toast.error("Phiên đăng nhập đã hết hạn. Vui lòng thử lại.");
+        setLoginStep("form");
+        setRequestId(null);
+      }
+    }, 2000); // Poll every 2 seconds
+  };
+
   useEffect(() => {
-    if (!isAuthReady || loginMutation.isPending || isRedirecting) {
+    if (!isAuthReady || staffLoginMutation.isPending || isRedirecting || isActivating) {
       return;
     }
 
@@ -148,7 +262,8 @@ function LoginPageContent() {
     getSearchParam,
     isAuthReady,
     isRedirecting,
-    loginMutation.isPending,
+    isActivating,
+    staffLoginMutation.isPending,
     queryClient,
     replace,
     setUser,
@@ -157,9 +272,112 @@ function LoginPageContent() {
 
   const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
     e.preventDefault();
-    loginMutation.mutate({ accountHandle, password, rememberMe });
+
+    // Try student login first (it will fail with 400 for non-students)
+    studentLoginInitMutation.mutate({ accountHandle, password, rememberMe });
   };
 
+  const handleBackToForm = () => {
+    setLoginStep("form");
+    setRequestId(null);
+    setAccountHandle("");
+    setPassword("");
+    setRememberMe(false);
+    if (pollTimerRef.current) {
+      clearInterval(pollTimerRef.current);
+      pollTimerRef.current = null;
+    }
+  };
+
+  const isLoading =
+    staffLoginMutation.isPending ||
+    studentLoginInitMutation.isPending ||
+    isRedirecting ||
+    isActivating;
+
+  // Blocked device screen
+  if (loginStep === "blocked") {
+    return (
+      <div className="flex min-h-dvh items-start justify-center bg-bg-primary px-4 py-6 sm:items-center sm:py-10">
+        <div className="w-full max-w-md motion-fade-up">
+          <div className="rounded-2xl border border-border-default bg-bg-surface p-5 shadow-lg motion-hover-lift sm:p-8">
+            <div className="mb-6 flex justify-center px-1 sm:mb-8">
+              <BrandLogoLockup
+                variant="auth"
+                className="max-w-full flex-wrap justify-center"
+                priority
+              />
+            </div>
+            <h1 className="text-2xl font-semibold text-text-primary text-center mb-4">
+              Tài khoản đang bị chặn
+            </h1>
+            <div className="rounded-lg bg-error/10 border border-error/20 p-4 mb-6">
+              <p className="text-sm text-error text-center">
+                Tài khoản này đang đăng nhập ở thiết bị khác. Mỗi học sinh chỉ được phép đăng nhập trên một thiết bị tại một thời điểm.
+              </p>
+            </div>
+            <div className="space-y-3 text-sm text-text-secondary">
+              <p className="font-medium text-text-primary">Cách khắc phục:</p>
+              <ul className="list-disc list-inside space-y-1.5">
+                <li>Đăng xuất trên thiết bị đang dùng</li>
+                <li>Liên hệ giáo viên hoặc quản trị viên để buộc đăng xuất</li>
+              </ul>
+            </div>
+            <button
+              onClick={handleBackToForm}
+              className="mt-6 w-full rounded-lg bg-primary py-2.5 font-medium text-text-inverse hover:bg-primary-hover active:bg-primary-active focus:outline-none focus:ring-2 focus:ring-border-focus focus:ring-offset-2 transition-colors duration-200"
+            >
+              Thử lại
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Pending verification screen
+  if (loginStep === "pending") {
+    return (
+      <div className="flex min-h-dvh items-start justify-center bg-bg-primary px-4 py-6 sm:items-center sm:py-10">
+        <div className="w-full max-w-md motion-fade-up">
+          <div className="rounded-2xl border border-border-default bg-bg-surface p-5 shadow-lg motion-hover-lift sm:p-8">
+            <div className="mb-6 flex justify-center px-1 sm:mb-8">
+              <BrandLogoLockup
+                variant="auth"
+                className="max-w-full flex-wrap justify-center"
+                priority
+              />
+            </div>
+            <h1 className="text-2xl font-semibold text-text-primary text-center mb-4">
+              Kiểm tra email của bạn
+            </h1>
+            <div className="rounded-lg bg-primary/10 border border-primary/20 p-4 mb-6">
+              <p className="text-sm text-primary text-center">
+                Chúng tôi đã gửi liên kết xác minh đến email của bạn. Vui lòng kiểm tra hộp thư và bấm liên kết để hoàn tất đăng nhập.
+              </p>
+            </div>
+            <div className="text-center text-sm text-text-secondary mb-6">
+              <p>Đang chờ xác minh…</p>
+              <div className="mt-3 flex justify-center">
+                <div className="size-6 animate-spin rounded-full border-2 border-border-default border-t-primary" />
+              </div>
+            </div>
+            <p className="text-xs text-text-muted text-center mb-4">
+              Liên kết hết hạn sau 10 phút.
+            </p>
+            <button
+              onClick={handleBackToForm}
+              className="w-full rounded-lg border border-border-default bg-bg-surface py-2.5 font-medium text-text-primary hover:bg-bg-tertiary focus:outline-none focus:ring-2 focus:ring-border-focus focus:ring-offset-2 transition-colors duration-200"
+            >
+              Hủy và quay lại
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Login form
   return (
     <div className="flex min-h-dvh items-start justify-center bg-bg-primary px-4 py-6 sm:items-center sm:py-10">
       <div className="w-full max-w-md motion-fade-up">
@@ -232,10 +450,10 @@ function LoginPageContent() {
 
             <button
               type="submit"
-              disabled={loginMutation.isPending || isRedirecting}
+              disabled={isLoading}
               className="w-full rounded-lg bg-primary py-2.5 font-medium text-text-inverse hover:bg-primary-hover active:bg-primary-active focus:outline-none focus:ring-2 focus:ring-border-focus focus:ring-offset-2 disabled:opacity-60 transition-colors duration-200"
             >
-              {loginMutation.isPending ? "Đang đăng nhập…" : isRedirecting ? "Đang chuyển tiếp…" : "Đăng nhập"}
+              {isLoading ? "Đang đăng nhập…" : "Đăng nhập"}
             </button>
 
             <div className="relative my-4">

--- a/apps/web/app/auth/login/page.tsx
+++ b/apps/web/app/auth/login/page.tsx
@@ -167,9 +167,17 @@ function LoginPageContent() {
       startPolling(response.requestId);
     },
     onError: (error) => {
-      // 400 = non-student account → fallback to staff/admin login
       if (isAxiosError(error) && error.response?.status === 400) {
-        staffLoginMutation.mutate({ accountHandle, password, rememberMe });
+        const errorCode = error.response.data?.error;
+        if (errorCode === "NOT_STUDENT_ACCOUNT") {
+          // Non-student account → fallback to staff/admin login
+          staffLoginMutation.mutate({ accountHandle, password, rememberMe });
+          return;
+        }
+        // EMAIL_NOT_VERIFIED or other 400 → show backend message
+        toast.error(
+          error.response.data?.message || "Đăng nhập thất bại.",
+        );
         return;
       }
       if (isAxiosError(error) && error.response?.status === 409) {

--- a/apps/web/app/auth/login/page.tsx
+++ b/apps/web/app/auth/login/page.tsx
@@ -9,7 +9,6 @@ import { isAxiosError } from "axios";
 import { toast } from "sonner";
 import * as authApi from "@/lib/apis/auth.api";
 import type { LoginDto } from "@/dtos/Auth.dto";
-import { Role } from "@/dtos/Auth.dto";
 import { useAuth } from "@/context/AuthContext";
 import { BrandLogoLockup } from "@/components/BrandLogoLockup";
 import { AuthCardSkeleton } from "@/components/auth/AuthCardSkeleton";
@@ -97,6 +96,7 @@ function LoginPageContent() {
   // Student login flow state
   const [loginStep, setLoginStep] = useState<LoginStep>("form");
   const [requestId, setRequestId] = useState<string | null>(null);
+  const [activateSecret, setActivateSecret] = useState<string | null>(null);
   const pollTimerRef = useRef<NodeJS.Timeout | null>(null);
   const [isActivating, setIsActivating] = useState(false);
 
@@ -161,11 +161,17 @@ function LoginPageContent() {
     },
     onSuccess: (response) => {
       setRequestId(response.requestId);
+      setActivateSecret(response.activateSecret);
       setLoginStep("pending");
       toast.success("Đã gửi email xác minh. Vui lòng kiểm tra hộp thư.");
       startPolling(response.requestId);
     },
     onError: (error) => {
+      // 400 = non-student account → fallback to staff/admin login
+      if (isAxiosError(error) && error.response?.status === 400) {
+        staffLoginMutation.mutate({ accountHandle, password, rememberMe });
+        return;
+      }
       if (isAxiosError(error) && error.response?.status === 409) {
         setLoginStep("blocked");
         return;
@@ -177,8 +183,10 @@ function LoginPageContent() {
   // Student activate
   const studentActivateMutation = useMutation({
     mutationFn: async (reqId: string) => {
+      if (!activateSecret) throw new Error("Missing activation secret");
       return authApi.studentActivate({
         requestId: reqId,
+        activateSecret,
         rememberMe,
       });
     },
@@ -280,6 +288,7 @@ function LoginPageContent() {
   const handleBackToForm = () => {
     setLoginStep("form");
     setRequestId(null);
+    setActivateSecret(null);
     setAccountHandle("");
     setPassword("");
     setRememberMe(false);

--- a/apps/web/app/auth/login/page.tsx
+++ b/apps/web/app/auth/login/page.tsx
@@ -94,8 +94,10 @@ function LoginPageContent() {
   const { setUser, user, isAuthReady } = useAuth();
 
   // Student login flow state
-  const [loginStep, setLoginStep] = useState<LoginStep>("form");
-  const [requestId, setRequestId] = useState<string | null>(null);
+  const [loginStep, setLoginStep] = useState<LoginStep>(() => {
+    const err = getSearchParam("error");
+    return err === "device_blocked" ? "blocked" : "form";
+  });
   const [activateSecret, setActivateSecret] = useState<string | null>(null);
   const pollTimerRef = useRef<NodeJS.Timeout | null>(null);
   const [isActivating, setIsActivating] = useState(false);
@@ -104,12 +106,8 @@ function LoginPageContent() {
     const err = getSearchParam("error");
     if (err === "registration_disabled") {
       toast.error("Tài khoản chưa tồn tại trong hệ thống. Vui lòng liên hệ quản trị viên để được cấp tài khoản.");
-      return;
     }
     if (err === "google_no_user") toast.error("Không lấy được thông tin từ Google. Vui lòng thử lại.");
-    if (err === "device_blocked") {
-      setLoginStep("blocked");
-    }
   }, [getSearchParam]);
 
   // Cleanup poll timer on unmount
@@ -160,7 +158,6 @@ function LoginPageContent() {
       return authApi.studentLoginInit(body);
     },
     onSuccess: (response) => {
-      setRequestId(response.requestId);
       setActivateSecret(response.activateSecret);
       setLoginStep("pending");
       toast.success("Đã gửi email xác minh. Vui lòng kiểm tra hộp thư.");
@@ -250,7 +247,6 @@ function LoginPageContent() {
         }
         toast.error("Phiên đăng nhập đã hết hạn. Vui lòng thử lại.");
         setLoginStep("form");
-        setRequestId(null);
       }
     }, 2000); // Poll every 2 seconds
   };
@@ -295,7 +291,6 @@ function LoginPageContent() {
 
   const handleBackToForm = () => {
     setLoginStep("form");
-    setRequestId(null);
     setActivateSecret(null);
     setAccountHandle("");
     setPassword("");

--- a/apps/web/app/auth/verify-login/page.tsx
+++ b/apps/web/app/auth/verify-login/page.tsx
@@ -11,15 +11,15 @@ type VerifyStatus = "loading" | "success" | "already" | "error";
 function VerifyLoginContent() {
   const searchParams = useSearchParams();
   const token = searchParams.get("token");
-  const [status, setStatus] = useState<VerifyStatus>("loading");
-  const [message, setMessage] = useState("");
+  const [status, setStatus] = useState<VerifyStatus>(() =>
+    token ? "loading" : "error",
+  );
+  const [message, setMessage] = useState(() =>
+    token ? "" : "Liên kết không hợp lệ.",
+  );
 
   useEffect(() => {
-    if (!token) {
-      setStatus("error");
-      setMessage("Liên kết không hợp lệ.");
-      return;
-    }
+    if (!token) return;
 
     authApi
       .verifyLoginLink(token)

--- a/apps/web/app/auth/verify-login/page.tsx
+++ b/apps/web/app/auth/verify-login/page.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import { Suspense, useEffect, useState } from "react";
+import * as authApi from "@/lib/apis/auth.api";
+import { BrandLogoLockup } from "@/components/BrandLogoLockup";
+import { AuthCardSkeleton } from "@/components/auth/AuthCardSkeleton";
+
+type VerifyStatus = "loading" | "success" | "already" | "error";
+
+function VerifyLoginContent() {
+  const searchParams = useSearchParams();
+  const token = searchParams.get("token");
+  const [status, setStatus] = useState<VerifyStatus>("loading");
+  const [message, setMessage] = useState("");
+
+  useEffect(() => {
+    if (!token) {
+      setStatus("error");
+      setMessage("Liên kết không hợp lệ.");
+      return;
+    }
+
+    authApi
+      .verifyLoginLink(token)
+      .then((result) => {
+        if (result.verified) {
+          // Check if it was already verified (opened on different device)
+          setStatus("already");
+          setMessage("Đã xác minh thành công. Quay lại thiết bị vừa đăng nhập để hoàn tất.");
+        } else {
+          setStatus("success");
+          setMessage("Đã xác minh thành công. Quay lại thiết bị vừa đăng nhập để hoàn tất.");
+        }
+      })
+      .catch(() => {
+        setStatus("error");
+        setMessage("Liên kết không hợp lệ hoặc đã hết hạn.");
+      });
+  }, [token]);
+
+  return (
+    <div className="flex min-h-dvh items-start justify-center bg-bg-primary px-4 py-6 sm:items-center sm:py-10">
+      <div className="w-full max-w-md motion-fade-up">
+        <div className="rounded-2xl border border-border-default bg-bg-surface p-5 shadow-lg motion-hover-lift sm:p-8">
+          <div className="mb-6 flex justify-center px-1 sm:mb-8">
+            <BrandLogoLockup
+              variant="auth"
+              className="max-w-full flex-wrap justify-center"
+              priority
+            />
+          </div>
+
+          {status === "loading" && (
+            <div className="text-center">
+              <div className="mb-4 flex justify-center">
+                <div className="size-8 animate-spin rounded-full border-2 border-border-default border-t-primary" />
+              </div>
+              <p className="text-text-secondary">Đang xác minh…</p>
+            </div>
+          )}
+
+          {status === "success" && (
+            <div className="text-center">
+              <div className="mb-4 flex justify-center">
+                <div className="flex size-12 items-center justify-center rounded-full bg-success/10">
+                  <svg
+                    className="size-6 text-success"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    strokeWidth={2}
+                    stroke="currentColor"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M4.5 12.75l6 6 9-13.5"
+                    />
+                  </svg>
+                </div>
+              </div>
+              <h1 className="text-xl font-semibold text-text-primary mb-2">
+                Đã xác minh
+              </h1>
+              <p className="text-sm text-text-secondary">{message}</p>
+            </div>
+          )}
+
+          {status === "already" && (
+            <div className="text-center">
+              <div className="mb-4 flex justify-center">
+                <div className="flex size-12 items-center justify-center rounded-full bg-primary/10">
+                  <svg
+                    className="size-6 text-primary"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    strokeWidth={2}
+                    stroke="currentColor"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M4.5 12.75l6 6 9-13.5"
+                    />
+                  </svg>
+                </div>
+              </div>
+              <h1 className="text-xl font-semibold text-text-primary mb-2">
+                Đã xác minh
+              </h1>
+              <p className="text-sm text-text-secondary">{message}</p>
+            </div>
+          )}
+
+          {status === "error" && (
+            <div className="text-center">
+              <div className="mb-4 flex justify-center">
+                <div className="flex size-12 items-center justify-center rounded-full bg-error/10">
+                  <svg
+                    className="size-6 text-error"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    strokeWidth={2}
+                    stroke="currentColor"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M6 18L18 6M6 6l12 12"
+                    />
+                  </svg>
+                </div>
+              </div>
+              <h1 className="text-xl font-semibold text-text-primary mb-2">
+                Lỗi
+              </h1>
+              <p className="text-sm text-text-secondary">{message}</p>
+            </div>
+          )}
+
+          <p className="mt-6 text-center text-xs text-text-muted">
+            Đóng trang này và quay lại thiết bị vừa đăng nhập.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function VerifyLoginPage() {
+  return (
+    <Suspense
+      fallback={
+        <AuthCardSkeleton showInlineActions={false} showDivider={false} showSecondaryButton={false} footerRows={0} />
+      }
+    >
+      <VerifyLoginContent />
+    </Suspense>
+  );
+}

--- a/apps/web/components/student/StudentHeader.tsx
+++ b/apps/web/components/student/StudentHeader.tsx
@@ -23,7 +23,7 @@ export default function StudentHeader() {
   });
 
   const logoutMutation = useMutation({
-    mutationFn: () => authApi.logout(),
+    mutationFn: () => authApi.studentLogout(),
     onSuccess: async () => {
       clearLogoutScopedQueries(queryClient);
       toast.success("Đã đăng xuất");

--- a/apps/web/components/student/StudentSidebar.tsx
+++ b/apps/web/components/student/StudentSidebar.tsx
@@ -158,7 +158,7 @@ export default function StudentSidebar() {
     : "translateX(0)";
 
   const logoutMutation = useMutation({
-    mutationFn: authApi.logout,
+    mutationFn: authApi.studentLogout,
     onSuccess: async () => {
       await clearLogoutScopedQueries(queryClient);
       setUser({

--- a/apps/web/dtos/Auth.dto.ts
+++ b/apps/web/dtos/Auth.dto.ts
@@ -107,16 +107,17 @@ export interface SetupPasswordDto {
 
 export interface StudentLoginInitResponse {
   requestId: string;
+  activateSecret: string;
   message: string;
 }
 
 export interface StudentLoginPollResponse {
   verified: boolean;
-  requestId: string;
 }
 
 export interface StudentActivateDto {
   requestId: string;
+  activateSecret: string;
   rememberMe?: boolean;
 }
 

--- a/apps/web/dtos/Auth.dto.ts
+++ b/apps/web/dtos/Auth.dto.ts
@@ -104,3 +104,22 @@ export interface LoginResponseDto {
 export interface SetupPasswordDto {
   password: string;
 }
+
+export interface StudentLoginInitResponse {
+  requestId: string;
+  message: string;
+}
+
+export interface StudentLoginPollResponse {
+  verified: boolean;
+  requestId: string;
+}
+
+export interface StudentActivateDto {
+  requestId: string;
+  rememberMe?: boolean;
+}
+
+export interface StudentActivateResponse {
+  message: string;
+}

--- a/apps/web/lib/apis/auth.api.ts
+++ b/apps/web/lib/apis/auth.api.ts
@@ -435,8 +435,9 @@ export async function studentLoginInit(
 export async function studentLoginPoll(
   requestId: string,
 ): Promise<StudentLoginPollResponse> {
-  const response = await api.get<StudentLoginPollResponse>(
-    `/auth/student/login/${encodeURIComponent(requestId)}/poll`,
+  const response = await api.post<StudentLoginPollResponse>(
+    "/auth/student/login/poll",
+    { requestId },
   );
   return response.data;
 }

--- a/apps/web/lib/apis/auth.api.ts
+++ b/apps/web/lib/apis/auth.api.ts
@@ -6,6 +6,10 @@ import {
   RegisterDto,
   ResetPasswordDto,
   SetupPasswordDto,
+  StudentActivateDto,
+  StudentActivateResponse,
+  StudentLoginInitResponse,
+  StudentLoginPollResponse,
   UserInfoDto,
 } from "@/dtos/Auth.dto";
 import type {
@@ -109,6 +113,11 @@ export async function setupPassword(data: SetupPasswordDto) {
 
 export async function logout() {
   const response = await api.post("/auth/logout");
+  return response.data;
+}
+
+export async function studentLogout() {
+  const response = await api.post("/auth/student/logout");
   return response.data;
 }
 
@@ -409,4 +418,49 @@ export async function getMyStaffLessonOutputStats(params?: {
   );
 
   return response.data;
+}
+
+// ─── Student single-device login ─────────────────────────────────────
+
+export async function studentLoginInit(
+  dto: LoginDto,
+): Promise<StudentLoginInitResponse> {
+  const response = await api.post<StudentLoginInitResponse>(
+    "/auth/student/login",
+    dto,
+  );
+  return response.data;
+}
+
+export async function studentLoginPoll(
+  requestId: string,
+): Promise<StudentLoginPollResponse> {
+  const response = await api.get<StudentLoginPollResponse>(
+    `/auth/student/login/${encodeURIComponent(requestId)}/poll`,
+  );
+  return response.data;
+}
+
+export async function studentActivate(
+  dto: StudentActivateDto,
+): Promise<StudentActivateResponse> {
+  const response = await api.post<StudentActivateResponse>(
+    "/auth/student/activate",
+    dto,
+  );
+  return response.data;
+}
+
+export async function verifyLoginLink(token: string) {
+  const response = await api.get(
+    `/auth/verify-login?token=${encodeURIComponent(token)}`,
+  );
+  return response.data as { message: string; verified: boolean };
+}
+
+export async function forceLogoutStudent(studentId: string) {
+  const response = await api.post(
+    `/auth/admin/students/${encodeURIComponent(studentId)}/force-logout`,
+  );
+  return response.data as { message: string };
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -47,6 +47,12 @@ Mọi thay đổi đáng kể của dự án được ghi lại tại file này.
   - Frontend: login page xử lý cả student và staff/admin flow; màn hình "Check your email" với polling; màn hình blocked device (Screen 18).
   - Frontend: `verify-login` page cho magic link.
   - Student sidebar/header dùng `POST /auth/student/logout` để cleanup device khi đăng xuất.
+  - `POST /auth/student/login/poll` đổi từ GET sang POST, requestId đưa vào body thay vì URL path để tránh leak trong access logs.
+  - Activate endpoint yêu cầu `activateSecret` (one-time secret trả về từ bước login init) kèm `requestId`, không còn dựa vào requestId UUID làm secret duy nhất.
+  - Device check cho student được áp dụng trên mỗi access token validation (`JwtStrategy.validate`), không chỉ ở refresh. Kết quả cache trong `AuthIdentityCacheService` (TTL 5s), invalidate khi force-logout/xóa device.
+  - `touchDevice` gọi trên mỗi refresh để rule inactive 60 ngày hoạt động đúng.
+  - `studentLoginInit` trả `error: NOT_STUDENT_ACCOUNT` hoặc `error: EMAIL_NOT_VERIFIED` riêng biệt; FE chỉ fallback sang staff login khi gặp `NOT_STUDENT_ACCOUNT`.
+  - Kiểm tra roleType chuyển xuống sau bcrypt.compare để tránh account enumeration.
 
 - **Migration — Backfill hồ sơ `student_info` cho toàn bộ tài khoản `users` có role `student`:**
   - Tạo migration `20260904090000_backfill_student_info_for_student_users` tự động đồng bộ hồ sơ `student_info` cho các tài khoản người dùng có role `student` nhưng chưa có profile (như tài khoản `hocsinh1` và các tài khoản test/legacy khác).

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -37,6 +37,17 @@ Mọi thay đổi đáng kể của dự án được ghi lại tại file này.
   - Tuition/allowance vẫn tính đúng — `tuitionFee` = tổng `present`/`excused` × học phí mỗi học sinh.
   - **Migration:** `20260905100000_add_class_no_attendance` — thêm `no_attendance` vào `classes`, `snapshot_no_attendance` vào `sessions`.
 
+- **Student single-device login (ticket #65):**
+  - Thêm bảng `user_devices` và `login_requests` trong Prisma schema.
+  - Luật một thiết bị tại một thời điểm cho tài khoản học sinh: khi đăng nhập ở máy thứ hai khi máy cũ còn hiệu lực → bị chặn, hiện màn hình lỗi rõ lý do và cách gỡ.
+  - Flow đăng nhập học sinh mới: nhập credentials → gửi magic link email → poll chờ xác minh → activate device + cấp JWT tokens.
+  - `StudentDeviceGuard` trên `POST /auth/refresh`: kiểm tra student có device active không trước khi cấp token mới.
+  - Endpoint `POST /auth/admin/students/:id/force-logout`: admin/CSKH/assistant buộc đăng xuất học sinh, ghi audit trail.
+  - Lazy cleanup: xóa login requests hết hạn và devices inactive > 60 ngày khi tạo login request mới.
+  - Frontend: login page xử lý cả student và staff/admin flow; màn hình "Check your email" với polling; màn hình blocked device (Screen 18).
+  - Frontend: `verify-login` page cho magic link.
+  - Student sidebar/header dùng `POST /auth/student/logout` để cleanup device khi đăng xuất.
+
 - **Migration — Backfill hồ sơ `student_info` cho toàn bộ tài khoản `users` có role `student`:**
   - Tạo migration `20260904090000_backfill_student_info_for_student_users` tự động đồng bộ hồ sơ `student_info` cho các tài khoản người dùng có role `student` nhưng chưa có profile (như tài khoản `hocsinh1` và các tài khoản test/legacy khác).
   - Quy trình xử lý 2 bước: (1) Tự động liên kết các bản ghi `student_info` mồ côi nếu trùng email với tài khoản học sinh; (2) Tự động sinh ID chuẩn `UNIST-[0-9a-f]{10}` và chèn hồ sơ `student_info` mới (họ tên lấy theo `last_name + first_name` hoặc `account_handle`, trạng thái `active`, số dư ví `0 đ`, quyền nhận biên lai email) cho tất cả các tài khoản học sinh còn lại.

--- a/docs/Database Schema.md
+++ b/docs/Database Schema.md
@@ -24,6 +24,8 @@ Tài liệu này được tổng hợp trực tiếp từ Prisma schema tại `a
 ### Auth
 
 - `users`
+- `user_devices` (phiên đăng nhập học sinh, luật một thiết bị tại một thời điểm)
+- `login_requests` (yêu cầu đăng nhập tạm, gắn với trình duyệt khởi tạo)
 
 ### People
 
@@ -121,6 +123,34 @@ Tài liệu này được tổng hợp trực tiếp từ Prisma schema tại `a
 - `DELETE /users/:id` (admin/assistant): soft-delete tài khoản — gỡ `staff_info.user_id` / `student_info.user_id` về `null` (giữ hồ sơ), các FK nullable khác (`action_history.user_id`, `notifications.created_by_user_id`, `regulations.*_by_user_id`, wallet order/request creator, …) theo `ON DELETE SET NULL`, `notification_reads` cascade theo user; sau đó xóa row `users`.
 - Không còn field legacy `person_profile_id` trong schema được hỗ trợ.
 - Index: `email`, `phone`, `account_handle`, `link_id`, `role_type`, `status`, `created_at`
+
+### 4.1.1 `user_devices` (Student single-device login)
+
+- PK: `id` (UUID default)
+- FK: `user_id` → `users.id` (ON DELETE CASCADE)
+- Fields:
+  - `token_hash` (`TEXT`, unique): SHA-256 hash của device token, dùng để xác thực thiết bị
+  - `device_info` (`JSONB`, nullable): thông tin trình duyệt/device (user-agent, accept-language)
+  - `ip_address` (`TEXT`, nullable): IP address khi đăng nhập
+  - `last_active_at` (`TIMESTAMPTZ(6)`): lần hoạt động cuối cùng, dùng để auto-expire sau 60 ngày
+  - `created_at` (`TIMESTAMPTZ(6)`)
+- Luật: mỗi học sinh chỉ có đúng 1 device active tại một thời điểm. Staff/admin không bị ràng buộc.
+- Auto-expire: device bị xóa sau 60 ngày không hoạt động (lazy cleanup khi tạo login request mới).
+- Index: `user_id`, `token_hash`, `last_active_at`
+
+### 4.1.2 `login_requests` (Magic link verification)
+
+- PK: `id` (UUID default)
+- FK: `user_id` → `users.id` (ON DELETE CASCADE)
+- Fields:
+  - `token_hash` (`TEXT`, unique): SHA-256 hash của login token
+  - `verified` (`BOOLEAN`, default false): đã bấm link xác minh chưa
+  - `device_info` (`JSONB`, nullable): thông tin trình duyệt khởi tạo
+  - `ip_address` (`TEXT`, nullable): IP address khi tạo request
+  - `expires_at` (`TIMESTAMPTZ(6)`): hết hạn sau 10 phút
+  - `created_at` (`TIMESTAMPTZ(6)`)
+- Flow: tạo request → gửi magic link email → user bấm link → `verified = true` → frontend poll nhận biết → activate device + cấp JWT tokens.
+- Cleanup: xóa bản ghi hết hạn khi tạo login request mới (lazy).
 
 ### 4.2 `staff_info`
 

--- a/docs/pages/auth.md
+++ b/docs/pages/auth.md
@@ -127,16 +127,18 @@ export default async function SomePage() {
 Luật một thiết bị tại một thời điểm, chỉ áp dụng cho `UserRole.student`. Staff/admin giữ nguyên flow cũ.
 
 - `POST /auth/student/login` body: `{ accountHandle, password, rememberMe? }`
-  - Validate credentials, kiểm tra `roleType === student`, kiểm tra đã `emailVerified`.
+  - Validate credentials, kiểm tra đã `emailVerified`.
+  - Nếu `roleType !== student` → trả `400` với `error: NOT_STUDENT_ACCOUNT`.
+  - Nếu email chưa xác minh → trả `400` với `error: EMAIL_NOT_VERIFIED`.
   - Nếu student đã có device active → trả `409` với `error: DEVICE_ACTIVE`.
   - Tạo `login_requests` record, gửi magic link email tới student.
-  - Response: `{ requestId, message }`.
+  - Response: `{ requestId, activateSecret, message }`. `activateSecret` là one-time secret dùng ở bước activate; frontend lưu trong memory, không lưu localStorage.
   - Rate limit: `5` request / `60s` / IP.
 
-- `GET /auth/student/login/:requestId/poll`
+- `POST /auth/student/login/poll` body: `{ requestId }`
   - Frontend poll mỗi 2s để kiểm tra trạng thái xác minh.
-  - Response: `{ verified: boolean, requestId }`.
-  - Khi `verified = true`, frontend gọi `POST /auth/student/activate`.
+  - Response: `{ verified: boolean }`.
+  - Khi `verified = true`, frontend gọi `POST /auth/student/activate` kèm `requestId` + `activateSecret`.
   - Rate limit: `30` request / `60s` / IP.
 
 - `GET /auth/verify-login?token=...`
@@ -145,14 +147,15 @@ Luật một thiết bị tại một thời điểm, chỉ áp dụng cho `User
   - Trả `{ message, verified: true }`.
   - Rate limit: `30` request / `60s` / IP.
 
-- `POST /auth/student/activate` body: `{ requestId, rememberMe? }`
+- `POST /auth/student/activate` body: `{ requestId, activateSecret, rememberMe? }`
   - Sau khi poll xác nhận `verified = true`.
+  - Xác minh `activateSecret` khớp hash trong `login_requests`.
   - Xóa mọi device cũ của student (single-device rule).
   - Tạo `user_devices` record mới, cấp JWT tokens, set cookies.
   - Response: `{ message }`.
 
 - `POST /auth/student/logout`
-  - Student tự đăng xuất. Xóa device record và invalidate refresh token.
+  - Student tự đăng xuất. Xóa tất cả device records, invalidate refresh token.
   - Response: `{ message }`.
 
 - `POST /auth/admin/students/:id/force-logout`
@@ -164,6 +167,8 @@ Luật một thiết bị tại một thời điểm, chỉ áp dụng cho `User
   - Khi student refresh token, hệ thống kiểm tra có device active không.
   - Nếu không có device active → trả `401` với `error: NO_ACTIVE_DEVICE`.
   - Staff/admin không bị kiểm tra device.
+
+- Device check trong access token validation: `JwtStrategy.validate` kiểm tra `hasActiveDevice` cho student trên mỗi request. Kết quả được cache trong `AuthIdentityCacheService` (TTL 5s) để tránh round-trip DB mỗi request. Cache bị invalidate khi force-logout hoặc xóa device.
 
 - Lazy cleanup: khi tạo login request mới, tự động xóa login requests hết hạn và devices inactive > 60 ngày.
 - **Global rate limit:** các endpoint HTTP khác của API dùng limit mặc định `300` request / `60s` / endpoint / IP; health check `GET /` được `@SkipThrottle()`.

--- a/docs/pages/auth.md
+++ b/docs/pages/auth.md
@@ -121,6 +121,51 @@ export default async function SomePage() {
   - `POST /auth/change-password`
     - chỉ dùng khi tài khoản đã có mật khẩu và cần truyền `currentPassword`
     - rate limit: `10` request / `30 phút` / IP.
+
+### Student single-device login (ticket #65)
+
+Luật một thiết bị tại một thời điểm, chỉ áp dụng cho `UserRole.student`. Staff/admin giữ nguyên flow cũ.
+
+- `POST /auth/student/login` body: `{ accountHandle, password, rememberMe? }`
+  - Validate credentials, kiểm tra `roleType === student`, kiểm tra đã `emailVerified`.
+  - Nếu student đã có device active → trả `409` với `error: DEVICE_ACTIVE`.
+  - Tạo `login_requests` record, gửi magic link email tới student.
+  - Response: `{ requestId, message }`.
+  - Rate limit: `5` request / `60s` / IP.
+
+- `GET /auth/student/login/:requestId/poll`
+  - Frontend poll mỗi 2s để kiểm tra trạng thái xác minh.
+  - Response: `{ verified: boolean, requestId }`.
+  - Khi `verified = true`, frontend gọi `POST /auth/student/activate`.
+  - Rate limit: `30` request / `60s` / IP.
+
+- `GET /auth/verify-login?token=...`
+  - Magic link trong email trỏ tới endpoint này.
+  - Đánh dấu `login_requests.verified = true`.
+  - Trả `{ message, verified: true }`.
+  - Rate limit: `30` request / `60s` / IP.
+
+- `POST /auth/student/activate` body: `{ requestId, rememberMe? }`
+  - Sau khi poll xác nhận `verified = true`.
+  - Xóa mọi device cũ của student (single-device rule).
+  - Tạo `user_devices` record mới, cấp JWT tokens, set cookies.
+  - Response: `{ message }`.
+
+- `POST /auth/student/logout`
+  - Student tự đăng xuất. Xóa device record và invalidate refresh token.
+  - Response: `{ message }`.
+
+- `POST /auth/admin/students/:id/force-logout`
+  - Admin/CSKH/assistant buộc đăng xuất học sinh.
+  - Xóa mọi device records, invalidate refresh token, ghi audit trail.
+  - Yêu cầu `@Roles(UserRole.admin, UserRole.staff)`.
+
+- `POST /auth/refresh` — StudentDeviceGuard
+  - Khi student refresh token, hệ thống kiểm tra có device active không.
+  - Nếu không có device active → trả `401` với `error: NO_ACTIVE_DEVICE`.
+  - Staff/admin không bị kiểm tra device.
+
+- Lazy cleanup: khi tạo login request mới, tự động xóa login requests hết hạn và devices inactive > 60 ngày.
 - **Global rate limit:** các endpoint HTTP khác của API dùng limit mặc định `300` request / `60s` / endpoint / IP; health check `GET /` được `@SkipThrottle()`.
 - **Phản hồi khi vượt ngưỡng:** backend trả `429 Too Many Requests`; frontend nên surface message này qua Sonner toast như các lỗi auth khác.
 - **Contract:** Auth DTO và role enum aligned với backend.


### PR DESCRIPTION
## What

Luật một thiết bị tại một thời điểm cho tài khoản học sinh (ticket #65).

## Changes

### Backend
- Prisma schema: Thêm `user_devices` và `login_requests` tables
- UserDeviceService: CRUD cho user devices và login requests, hash token, lazy cleanup
- Student login flow: credentials → magic link email → poll → activate device
- StudentDeviceGuard: Kiểm tra student có device active trên refresh
- Force logout endpoint với audit trail
- MailService: Thêm sendLoginVerificationEmail method

### Frontend
- Login page: Xử lý cả student (magic link flow) và staff/admin (flow cũ)
- Verify-login page: Trang xác minh khi bấm magic link
- Blocked device screen: Hiện thông báo rõ lý do và cách gỡ
- Force-logout button trên trang chi tiết học sinh (admin)
- Student sidebar/header dùng student-specific logout endpoint

### Docs
- Database Schema.md: Thêm documentation cho tables mới
- auth.md: Thêm section Student single-device login
- CHANGELOG.md: Ghi log thay đổi

## Acceptance Criteria
- [x] UserDevice, đặt tên tránh hẳn từ session
- [x] Học sinh đăng nhập ở máy thứ hai khi máy cũ còn hiệu lực → bị chặn, hiện màn 18
- [x] Staff/admin đăng nhập nhiều thiết bị như cũ
- [x] Học sinh tự đăng xuất thì thiết bị được giải phóng ngay
- [x] Mobile-first