### PR TITLE
feat(auth): phân biệt trạng thái link magic-link khi xác minh (delta #66 trên nền #65)

### DIFF
--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -664,7 +664,7 @@ export class AuthController {
   @ApiOperation({
     summary: 'Verify login magic link',
     description:
-      'Marks a login request as verified when the student clicks the magic link from email.',
+      'Marks a login request as verified when the student clicks the magic link from email. Never sets a session on this device — the initiating browser (waiting screen) is the only device activated. Returns an outcome status so the UI can show distinct messages: verified / used / expired / invalid.',
   })
   @ApiQuery({
     name: 'token',
@@ -673,9 +673,9 @@ export class AuthController {
   })
   @ApiResponse({
     status: 200,
-    description: 'Login request verified.',
+    description:
+      'Outcome: { status: verified|used|expired|invalid, message, verified }.',
   })
-  @ApiResponse({ status: 400, description: 'Invalid or expired token.' })
   async verifyLogin(@Query('token') token: string) {
     return this.authService.verifyLoginMagicLink(token);
   }

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -1157,11 +1157,23 @@ export class AuthService {
     return tokenPair;
   }
 
-  async verifyLoginMagicLink(
-    token: string,
-  ): Promise<{ message: string; verified: boolean }> {
+  /**
+   * Máy bấm magic link trong email. KHÔNG set cookie hay tạo phiên trên máy
+   * này — thiết bị được kích hoạt luôn là máy khởi tạo (màn "Chờ xác minh").
+   * Trả `status` để FE hiển thị thông báo riêng cho từng case:
+   * `verified` / `used` (link đã được bấm trước đó) / `expired` / `invalid`.
+   */
+  async verifyLoginMagicLink(token: string): Promise<{
+    status: 'verified' | 'used' | 'expired' | 'invalid';
+    message: string;
+    verified: boolean;
+  }> {
     if (!token) {
-      throw new BadRequestException('Token is required');
+      return {
+        status: 'invalid',
+        message: 'Liên kết không hợp lệ.',
+        verified: false,
+      };
     }
 
     const tokenHash = this.userDeviceService.hashToken(token);
@@ -1169,19 +1181,39 @@ export class AuthService {
       await this.userDeviceService.findLoginRequestByTokenHash(tokenHash);
 
     if (!request) {
-      throw new BadRequestException('Invalid or expired login link');
+      return {
+        status: 'invalid',
+        message:
+          'Liên kết không hợp lệ hoặc đã bị cắt mất phần token. Vui lòng đăng nhập lại.',
+        verified: false,
+      };
     }
 
     if (new Date() > request.expiresAt) {
-      throw new BadRequestException('Login link expired');
+      return {
+        status: 'expired',
+        message:
+          'Liên kết xác minh đã hết hạn. Vui lòng đăng nhập lại để nhận liên kết mới.',
+        verified: false,
+      };
     }
 
     if (request.verified) {
-      return { message: 'Liên kết đã được xác minh', verified: true };
+      return {
+        status: 'used',
+        message:
+          'Liên kết này đã được sử dụng. Quay lại thiết bị vừa đăng nhập để hoàn tất.',
+        verified: true,
+      };
     }
 
     await this.userDeviceService.verifyLoginRequest(tokenHash);
-    return { message: 'Đã xác minh thành công', verified: true };
+    return {
+      status: 'verified',
+      message:
+        'Đã xác minh thành công. Quay lại thiết bị vừa đăng nhập để hoàn tất.',
+      verified: true,
+    };
   }
 
   async forceLogoutStudent(

--- a/apps/web/app/auth/verify-login/page.tsx
+++ b/apps/web/app/auth/verify-login/page.tsx
@@ -5,39 +5,85 @@ import { Suspense, useEffect, useState } from "react";
 import * as authApi from "@/lib/apis/auth.api";
 import { BrandLogoLockup } from "@/components/BrandLogoLockup";
 import { AuthCardSkeleton } from "@/components/auth/AuthCardSkeleton";
+import type { VerifyLoginStatus } from "@/dtos/Auth.dto";
 
-type VerifyStatus = "loading" | "success" | "already" | "error";
+type VerifyState = "loading" | VerifyLoginStatus;
+
+const STATE_CONTENT: Record<
+  Exclude<VerifyState, "loading">,
+  { tone: "success" | "primary" | "error"; title: string; message: string }
+> = {
+  verified: {
+    tone: "success",
+    title: "Xác minh thành công",
+    message:
+      "Đã xác minh yêu cầu đăng nhập. Quay lại máy/laptop vừa bấm Đăng nhập (màn hình “Chờ xác minh”) để hoàn tất — phiên được kích hoạt tại thiết bị đó.",
+  },
+  used: {
+    tone: "primary",
+    title: "Liên kết đã được sử dụng",
+    message:
+      "Liên kết xác minh này chỉ dùng được một lần và đã được bấm trước đó. Nếu bạn vẫn cần đăng nhập, hãy bấm Đăng nhập trên máy bạn muốn dùng.",
+  },
+  expired: {
+    tone: "error",
+    title: "Liên kết đã hết hạn",
+    message:
+      "Liên kết xác minh chỉ có hiệu lực 10 phút và đã hết hạn. Vui lòng đăng nhập lại để nhận một liên kết mới.",
+  },
+  invalid: {
+    tone: "error",
+    title: "Liên kết không hợp lệ",
+    message:
+      "Liên kết không hợp lệ hoặc đã bị cắt mất phần token. Vui lòng kiểm tra lại email hoặc đăng nhập lại.",
+  },
+};
+
+const TONE_STYLES = {
+  success: {
+    chip: "bg-success/10",
+    icon: "text-success",
+    path: "M4.5 12.75l6 6 9-13.5",
+  },
+  primary: {
+    chip: "bg-primary/10",
+    icon: "text-primary",
+    path: "M4.5 12.75l6 6 9-13.5",
+  },
+  error: {
+    chip: "bg-error/10",
+    icon: "text-error",
+    path: "M6 18L18 6M6 6l12 12",
+  },
+} as const;
 
 function VerifyLoginContent() {
   const searchParams = useSearchParams();
   const token = searchParams.get("token");
-  const [status, setStatus] = useState<VerifyStatus>(() =>
-    token ? "loading" : "error",
-  );
-  const [message, setMessage] = useState(() =>
-    token ? "" : "Liên kết không hợp lệ.",
+  const [state, setState] = useState<VerifyState>(() =>
+    token ? "loading" : "invalid",
   );
 
   useEffect(() => {
     if (!token) return;
 
+    let cancelled = false;
     authApi
       .verifyLoginLink(token)
       .then((result) => {
-        if (result.verified) {
-          // Check if it was already verified (opened on different device)
-          setStatus("already");
-          setMessage("Đã xác minh thành công. Quay lại thiết bị vừa đăng nhập để hoàn tất.");
-        } else {
-          setStatus("success");
-          setMessage("Đã xác minh thành công. Quay lại thiết bị vừa đăng nhập để hoàn tất.");
-        }
+        if (!cancelled) setState(result.status);
       })
       .catch(() => {
-        setStatus("error");
-        setMessage("Liên kết không hợp lệ hoặc đã hết hạn.");
+        if (!cancelled) setState("invalid");
       });
+    return () => {
+      cancelled = true;
+    };
   }, [token]);
+
+  const content =
+    state === "loading" ? null : STATE_CONTENT[state] ?? STATE_CONTENT.invalid;
+  const tone = content ? TONE_STYLES[content.tone] : null;
 
   return (
     <div className="flex min-h-dvh items-start justify-center bg-bg-primary px-4 py-6 sm:items-center sm:py-10">
@@ -51,21 +97,21 @@ function VerifyLoginContent() {
             />
           </div>
 
-          {status === "loading" && (
+          {state === "loading" && (
             <div className="text-center">
-              <div className="mb-4 flex justify-center">
-                <div className="size-8 animate-spin rounded-full border-2 border-border-default border-t-primary" />
-              </div>
+              <div className="mx-auto mb-5 size-8 animate-spin rounded-full border-2 border-border-default border-t-primary" />
               <p className="text-text-secondary">Đang xác minh…</p>
             </div>
           )}
 
-          {status === "success" && (
+          {content && tone && (
             <div className="text-center">
               <div className="mb-4 flex justify-center">
-                <div className="flex size-12 items-center justify-center rounded-full bg-success/10">
+                <div
+                  className={`flex size-12 items-center justify-center rounded-full ${tone.chip}`}
+                >
                   <svg
-                    className="size-6 text-success"
+                    className={`size-6 ${tone.icon}`}
                     fill="none"
                     viewBox="0 0 24 24"
                     strokeWidth={2}
@@ -74,67 +120,17 @@ function VerifyLoginContent() {
                     <path
                       strokeLinecap="round"
                       strokeLinejoin="round"
-                      d="M4.5 12.75l6 6 9-13.5"
+                      d={tone.path}
                     />
                   </svg>
                 </div>
               </div>
               <h1 className="text-xl font-semibold text-text-primary mb-2">
-                Đã xác minh
+                {content.title}
               </h1>
-              <p className="text-sm text-text-secondary">{message}</p>
-            </div>
-          )}
-
-          {status === "already" && (
-            <div className="text-center">
-              <div className="mb-4 flex justify-center">
-                <div className="flex size-12 items-center justify-center rounded-full bg-primary/10">
-                  <svg
-                    className="size-6 text-primary"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    strokeWidth={2}
-                    stroke="currentColor"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="M4.5 12.75l6 6 9-13.5"
-                    />
-                  </svg>
-                </div>
-              </div>
-              <h1 className="text-xl font-semibold text-text-primary mb-2">
-                Đã xác minh
-              </h1>
-              <p className="text-sm text-text-secondary">{message}</p>
-            </div>
-          )}
-
-          {status === "error" && (
-            <div className="text-center">
-              <div className="mb-4 flex justify-center">
-                <div className="flex size-12 items-center justify-center rounded-full bg-error/10">
-                  <svg
-                    className="size-6 text-error"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    strokeWidth={2}
-                    stroke="currentColor"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="M6 18L18 6M6 6l12 12"
-                    />
-                  </svg>
-                </div>
-              </div>
-              <h1 className="text-xl font-semibold text-text-primary mb-2">
-                Lỗi
-              </h1>
-              <p className="text-sm text-text-secondary">{message}</p>
+              <p className="text-sm leading-6 text-text-secondary">
+                {content.message}
+              </p>
             </div>
           )}
 
@@ -151,7 +147,12 @@ export default function VerifyLoginPage() {
   return (
     <Suspense
       fallback={
-        <AuthCardSkeleton showInlineActions={false} showDivider={false} showSecondaryButton={false} footerRows={0} />
+        <AuthCardSkeleton
+          showInlineActions={false}
+          showDivider={false}
+          showSecondaryButton={false}
+          footerRows={0}
+        />
       }
     >
       <VerifyLoginContent />

--- a/apps/web/dtos/Auth.dto.ts
+++ b/apps/web/dtos/Auth.dto.ts
@@ -124,3 +124,11 @@ export interface StudentActivateDto {
 export interface StudentActivateResponse {
   message: string;
 }
+
+export type VerifyLoginStatus = "verified" | "used" | "expired" | "invalid";
+
+export interface VerifyLoginResponse {
+  status: VerifyLoginStatus;
+  message: string;
+  verified: boolean;
+}

--- a/apps/web/lib/apis/auth.api.ts
+++ b/apps/web/lib/apis/auth.api.ts
@@ -11,6 +11,7 @@ import {
   StudentLoginInitResponse,
   StudentLoginPollResponse,
   UserInfoDto,
+  VerifyLoginResponse,
 } from "@/dtos/Auth.dto";
 import type {
   BonusListResponse,
@@ -452,11 +453,13 @@ export async function studentActivate(
   return response.data;
 }
 
-export async function verifyLoginLink(token: string) {
-  const response = await api.get(
+export async function verifyLoginLink(
+  token: string,
+): Promise<VerifyLoginResponse> {
+  const response = await api.get<VerifyLoginResponse>(
     `/auth/verify-login?token=${encodeURIComponent(token)}`,
   );
-  return response.data as { message: string; verified: boolean };
+  return response.data;
 }
 
 export async function forceLogoutStudent(studentId: string) {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,6 +30,11 @@ Mọi thay đổi đáng kể của dự án được ghi lại tại file này.
 
 ### Added
 
+- **Xác minh magic link học sinh — phân biệt trạng thái link (ticket #66, bổ sung trên nền #65):**
+  - `GET /auth/verify-login` trả `{ status, message, verified }` với `status: verified | used | expired | invalid` thay vì chỉ `{ message, verified }`.
+  - Máy bấm link lần đầu hợp lệ → `verified`; link đã được bấm trước đó (yêu cầu đã xác minh) → `used`; quá hạn 10 phút → `expired`; token sai/thiếu/không tồn tại → `invalid`. Không set cookie/kích hoạt phiên trên máy bấm link — thiết bị được kích hoạt vẫn là máy khởi tạo.
+  - Frontend `/auth/verify-login` hiển thị thông báo riêng cho từng trạng thái (Screen 17), đáp ứng AC "link hết hạn / đã dùng / sai có thông báo riêng".
+
 - **Cài đặt khoá — thời hạn, thang độ khó, đội giáo án (ticket #48):**
   - Prisma: thêm model + bảng `course_lesson_plan_members` (quan hệ `Course`–`StaffInfo`, unique `(course_id, staff_id)`, cascade xoá). Migration `20260907000000_add_course_lesson_plan_members`.
   - API `/courses`: `POST/PATCH` nhận và lưu `default_duration_days` (để trống/null = vô hạn); `GET /courses/:id` trả chi tiết kèm `difficultyLevels`, `lessonPlanMembers`, `_count.classes`; `GET /courses` trả `_count`.

--- a/docs/pages/auth.md
+++ b/docs/pages/auth.md
@@ -142,9 +142,14 @@ Luật một thiết bị tại một thời điểm, chỉ áp dụng cho `User
   - Rate limit: `30` request / `60s` / IP.
 
 - `GET /auth/verify-login?token=...`
-  - Magic link trong email trỏ tới endpoint này.
-  - Đánh dấu `login_requests.verified = true`.
-  - Trả `{ message, verified: true }`.
+  - Magic link trong email trỏ tới `/auth/verify-login` (FE), FE gọi endpoint này.
+  - Đánh dấu `login_requests.verified = true` (chỉ khi chưa verified và chưa hết hạn).
+  - **Không** set cookie/kích hoạt phiên trên máy bấm link — thiết bị được kích hoạt luôn là máy khởi tạo (màn chờ xác minh gọi `/auth/student/activate`).
+  - Trả `{ status, message, verified }` với `status` phân biệt để UI hiển thị thông báo riêng (ticket #66):
+    - `verified` — bấm lần đầu hợp lệ: "Đã xác minh thành công, quay lại thiết bị vừa đăng nhập".
+    - `used` — link đã được bấm trước đó (yêu cầu đã verified): "Liên kết đã được sử dụng".
+    - `expired` — quá `expires_at` (10 phút): "Liên kết đã hết hạn".
+    - `invalid` — token sai/thiếu/không tồn tại: "Liên kết không hợp lệ".
   - Rate limit: `30` request / `60s` / IP.
 
 - `POST /auth/student/activate` body: `{ requestId, activateSecret, rememberMe? }`


### PR DESCRIPTION
## Tóm tắt

Ticket #66 — sau khi **#65 (student single-device login) đã merge trên `dev`** kèm toàn bộ luồng magic-link/`LoginRequest` (shape #65: `verified boolean` + `activateSecret`), branch này được **rebase lại từ tip `origin/dev`** và thu gọn thành **delta #66 còn thiếu duy nhất**: phân biệt thông báo riêng cho **link hết hạn / link đã dùng / link sai** (AC #66), đúng tinh thần ADR "hai luồng đăng nhập song song phải cùng tồn tại".

Không giữ lại bất kỳ code LoginRequest thiết kế cũ của #66 (schema/enum/migration, cookie `login_request_secret`, endpoint `/auth/login-request/*`, 2 trang standalone) — tránh trùng lặp model/flow với #65.

## Thay đổi

- **BE** `GET /auth/verify-login` — `auth.service.verifyLoginMagicLink` trả `{ status, message, verified }` với `status: verified | used | expired | invalid` (thay vì chỉ `{ message, verified }` + throw 400):
  - `verified` — bấm link lần đầu hợp lệ.
  - `used` — link đã được bấm trước đó (request đã verified).
  - `expired` — quá `expires_at` (10 phút).
  - `invalid` — token sai/thiếu/không tồn tại.
  - Máy bấm link **không bao giờ** nhận cookie/phiên — thiết bị kích hoạt vẫn là máy khởi tạo (màn chờ xác minh → `/auth/student/activate`).
- **FE** `/auth/verify-login` (màn 17) render thông báo riêng theo `status`.
- **DTO/api client**: `VerifyLoginResponse`, `VerifyLoginStatus`.
- **Docs**: `docs/pages/auth.md`, `docs/CHANGELOG.md`.

## Kiểm tra

- `prisma validate` OK (không đổi schema/migration).
- API `tsc --noEmit` sạch; `jest src/auth`: **10 suites / 88 tests pass**.
- Web eslint sạch trên file đổi; web `tsc` không có lỗi từ file đổi (lỗi asset `next-env`/logo pre-existing trong worktree).

## Lưu ý

- `login_requests`/`user_devices` là bảng ngắn hạn; #65 đã có lazy cleanup khi tạo login request mới, nhưng chưa có cron nền dọn độc lập — theo ADR, cần ticket riêng nếu muốn cron chủ động (không chặn merge).
- Cần `/code-review low` trước khi merge theo `AGENTS.md`.
