### PR TITLE
feat: Quản trị thiết bị và force-logout (#67)

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -32,6 +32,7 @@ import { DeductionSettingsModule } from './deduction-settings/deduction-settings
 import { AchievementModule } from './achievements/achievement.module';
 import { StudentGalleryModule } from './student-gallery/student-gallery.module';
 import { TopicModule } from './topic/topic.module';
+import { DeviceModule } from './device/device.module';
 
 function parsePositiveIntegerEnv(
   value: string | undefined,
@@ -88,6 +89,7 @@ function parsePositiveIntegerEnv(
     AchievementModule,
     StudentGalleryModule,
     TopicModule,
+    DeviceModule,
   ],
   controllers: [AppController],
   providers: [

--- a/apps/api/src/device/device.controller.ts
+++ b/apps/api/src/device/device.controller.ts
@@ -6,7 +6,6 @@ import {
   HttpStatus,
   Param,
   Query,
-  UseGuards,
 } from '@nestjs/common';
 import {
   ApiCookieAuth,
@@ -20,7 +19,10 @@ import { UserRole } from 'generated/enums';
 import { Roles } from 'src/auth/decorators/roles.decorator';
 import { AllowStaffRolesOnAdminRoutes } from 'src/auth/decorators/allow-staff-roles-on-admin.decorator';
 import { AllowAssistantOnAdminRoutes } from 'src/auth/decorators/allow-assistant-on-admin.decorator';
-import { CurrentUser, type JwtPayload } from 'src/auth/decorators/current-user.decorator';
+import {
+  CurrentUser,
+  type JwtPayload,
+} from 'src/auth/decorators/current-user.decorator';
 import { StaffRole } from 'generated/enums';
 import { DeviceService } from './device.service';
 
@@ -28,7 +30,11 @@ import { DeviceService } from './device.service';
 @Controller('device')
 @ApiCookieAuth('access_token')
 @Roles(UserRole.admin)
-@AllowStaffRolesOnAdminRoutes(StaffRole.admin, StaffRole.customer_care, StaffRole.assistant)
+@AllowStaffRolesOnAdminRoutes(
+  StaffRole.admin,
+  StaffRole.customer_care,
+  StaffRole.assistant,
+)
 @AllowAssistantOnAdminRoutes()
 export class DeviceController {
   constructor(private readonly deviceService: DeviceService) {}
@@ -36,10 +42,15 @@ export class DeviceController {
   @Get('student/:studentId')
   @ApiOperation({
     summary: 'Lấy danh sách thiết bị của học sinh',
-    description: 'Trả về danh sách thiết bị hiện tại và lịch sử đăng nhập của học sinh.',
+    description:
+      'Trả về danh sách thiết bị hiện tại và lịch sử đăng nhập của học sinh.',
   })
   @ApiParam({ name: 'studentId', description: 'ID học sinh (UNIST-*)' })
-  @ApiQuery({ name: 'includeExpired', required: false, description: 'Bao gồm thiết bị đã hết hạn' })
+  @ApiQuery({
+    name: 'includeExpired',
+    required: false,
+    description: 'Bao gồm thiết bị đã hết hạn',
+  })
   @ApiResponse({ status: 200, description: 'Danh sách thiết bị' })
   @ApiResponse({ status: 404, description: 'Không tìm thấy học sinh' })
   async getStudentDevices(
@@ -47,7 +58,7 @@ export class DeviceController {
     @Query('includeExpired') includeExpired?: string,
   ) {
     const devices = await this.deviceService.getDevicesByUserId(studentId);
-    
+
     if (includeExpired !== 'true') {
       return devices.filter((d) => !d.isExpired);
     }
@@ -59,7 +70,8 @@ export class DeviceController {
   @HttpCode(HttpStatus.OK)
   @ApiOperation({
     summary: 'Buộc đăng xuất thiết bị',
-    description: 'Xóa phiên đăng nhập hiện tại của thiết bị, buộc học sinh phải đăng nhập lại.',
+    description:
+      'Xóa phiên đăng nhập hiện tại của thiết bị, buộc học sinh phải đăng nhập lại.',
   })
   @ApiParam({ name: 'deviceId', description: 'ID thiết bị' })
   @ApiResponse({ status: 200, description: 'Đã buộc đăng xuất thành công' })

--- a/apps/api/src/device/device.controller.ts
+++ b/apps/api/src/device/device.controller.ts
@@ -1,0 +1,92 @@
+import {
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiCookieAuth,
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { UserRole } from 'generated/enums';
+import { Roles } from 'src/auth/decorators/roles.decorator';
+import { AllowStaffRolesOnAdminRoutes } from 'src/auth/decorators/allow-staff-roles-on-admin.decorator';
+import { AllowAssistantOnAdminRoutes } from 'src/auth/decorators/allow-assistant-on-admin.decorator';
+import { CurrentUser, type JwtPayload } from 'src/auth/decorators/current-user.decorator';
+import { StaffRole } from 'generated/enums';
+import { DeviceService } from './device.service';
+
+@ApiTags('device')
+@Controller('device')
+@ApiCookieAuth('access_token')
+@Roles(UserRole.admin)
+@AllowStaffRolesOnAdminRoutes(StaffRole.admin, StaffRole.customer_care, StaffRole.assistant)
+@AllowAssistantOnAdminRoutes()
+export class DeviceController {
+  constructor(private readonly deviceService: DeviceService) {}
+
+  @Get('student/:studentId')
+  @ApiOperation({
+    summary: 'Lấy danh sách thiết bị của học sinh',
+    description: 'Trả về danh sách thiết bị hiện tại và lịch sử đăng nhập của học sinh.',
+  })
+  @ApiParam({ name: 'studentId', description: 'ID học sinh (UNIST-*)' })
+  @ApiQuery({ name: 'includeExpired', required: false, description: 'Bao gồm thiết bị đã hết hạn' })
+  @ApiResponse({ status: 200, description: 'Danh sách thiết bị' })
+  @ApiResponse({ status: 404, description: 'Không tìm thấy học sinh' })
+  async getStudentDevices(
+    @Param('studentId') studentId: string,
+    @Query('includeExpired') includeExpired?: string,
+  ) {
+    const devices = await this.deviceService.getDevicesByUserId(studentId);
+    
+    if (includeExpired !== 'true') {
+      return devices.filter((d) => !d.isExpired);
+    }
+
+    return devices;
+  }
+
+  @Delete(':deviceId/force-logout')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Buộc đăng xuất thiết bị',
+    description: 'Xóa phiên đăng nhập hiện tại của thiết bị, buộc học sinh phải đăng nhập lại.',
+  })
+  @ApiParam({ name: 'deviceId', description: 'ID thiết bị' })
+  @ApiResponse({ status: 200, description: 'Đã buộc đăng xuất thành công' })
+  @ApiResponse({ status: 404, description: 'Không tìm thấy thiết bị' })
+  async forceLogout(
+    @Param('deviceId') deviceId: string,
+    @CurrentUser() user: JwtPayload,
+  ) {
+    return this.deviceService.forceLogoutDevice(
+      deviceId,
+      {
+        userId: user.id,
+        userEmail: user.accountHandle,
+        roleType: user.roleType,
+      },
+      'Buộc đăng xuất thiết bị qua trang quản trị',
+    );
+  }
+
+  @Delete('cleanup-expired')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Dọn dẹp thiết bị hết hạn',
+    description: 'Xóa các thiết bị không hoạt động quá 60 ngày.',
+  })
+  @ApiResponse({ status: 200, description: 'Đã dọn dẹp thành công' })
+  async cleanupExpired() {
+    return this.deviceService.cleanupExpiredDevices();
+  }
+}

--- a/apps/api/src/device/device.module.ts
+++ b/apps/api/src/device/device.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { ActionHistoryModule } from 'src/action-history/action-history.module';
+import { PrismaModule } from 'src/prisma/prisma.module';
+import { DeviceController } from './device.controller';
+import { DeviceService } from './device.service';
+
+@Module({
+  imports: [PrismaModule, ConfigModule, ActionHistoryModule],
+  controllers: [DeviceController],
+  providers: [DeviceService],
+  exports: [DeviceService],
+})
+export class DeviceModule {}

--- a/apps/api/src/device/device.service.ts
+++ b/apps/api/src/device/device.service.ts
@@ -1,0 +1,103 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { ActionHistoryService } from '../action-history/action-history.service';
+
+const DEVICE_EXPIRY_DAYS = 60;
+
+@Injectable()
+export class DeviceService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly actionHistoryService: ActionHistoryService,
+  ) {}
+
+  async getDevicesByUserId(userId: string) {
+    const devices = await this.prisma.userDevice.findMany({
+      where: { userId },
+      orderBy: { lastActiveAt: 'desc' },
+    });
+
+    const now = new Date();
+    return devices.map((device) => {
+      const lastActive = new Date(device.lastActiveAt);
+      const daysSinceActive = Math.floor(
+        (now.getTime() - lastActive.getTime()) / (1000 * 60 * 60 * 24),
+      );
+      const isActive = daysSinceActive < DEVICE_EXPIRY_DAYS;
+      const isExpired = daysSinceActive >= DEVICE_EXPIRY_DAYS;
+
+      return {
+        ...device,
+        isActive,
+        isExpired,
+        daysSinceActive,
+      };
+    });
+  }
+
+  async getDeviceById(deviceId: string) {
+    const device = await this.prisma.userDevice.findUnique({
+      where: { id: deviceId },
+      include: { user: true },
+    });
+
+    if (!device) {
+      throw new NotFoundException('Device not found');
+    }
+
+    return device;
+  }
+
+  async forceLogoutDevice(
+    deviceId: string,
+    actor: {
+      userId: string;
+      userEmail: string;
+      roleType: string;
+    },
+    description?: string,
+  ) {
+    const device = await this.getDeviceById(deviceId);
+
+    await this.prisma.$transaction(async (tx) => {
+      const deviceSnapshot = {
+        id: device.id,
+        userId: device.userId,
+        deviceInfo: device.deviceInfo,
+        ipAddress: device.ipAddress,
+        lastActiveAt: device.lastActiveAt,
+        createdAt: device.createdAt,
+      };
+
+      await tx.userDevice.delete({
+        where: { id: deviceId },
+      });
+
+      await this.actionHistoryService.recordUpdate(tx, {
+        actor,
+        entityType: 'user_device',
+        entityId: deviceId,
+        description: description ?? 'Buộc đăng xuất thiết bị',
+        beforeValue: deviceSnapshot,
+        afterValue: null,
+      });
+    });
+
+    return { message: 'Đã buộc đăng xuất thiết bị' };
+  }
+
+  async cleanupExpiredDevices() {
+    const cutoffDate = new Date();
+    cutoffDate.setDate(cutoffDate.getDate() - DEVICE_EXPIRY_DAYS);
+
+    const result = await this.prisma.userDevice.deleteMany({
+      where: {
+        lastActiveAt: {
+          lt: cutoffDate,
+        },
+      },
+    });
+
+    return { deletedCount: result.count };
+  }
+}

--- a/apps/api/src/device/device.service.ts
+++ b/apps/api/src/device/device.service.ts
@@ -1,8 +1,7 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { ActionHistoryService } from '../action-history/action-history.service';
-
-const DEVICE_EXPIRY_DAYS = 60;
+import { DEVICE_INACTIVITY_DAYS } from '../auth/user-device.service';
 
 @Injectable()
 export class DeviceService {
@@ -23,8 +22,8 @@ export class DeviceService {
       const daysSinceActive = Math.floor(
         (now.getTime() - lastActive.getTime()) / (1000 * 60 * 60 * 24),
       );
-      const isActive = daysSinceActive < DEVICE_EXPIRY_DAYS;
-      const isExpired = daysSinceActive >= DEVICE_EXPIRY_DAYS;
+      const isActive = daysSinceActive < DEVICE_INACTIVITY_DAYS;
+      const isExpired = daysSinceActive >= DEVICE_INACTIVITY_DAYS;
 
       return {
         ...device,
@@ -88,7 +87,7 @@ export class DeviceService {
 
   async cleanupExpiredDevices() {
     const cutoffDate = new Date();
-    cutoffDate.setDate(cutoffDate.getDate() - DEVICE_EXPIRY_DAYS);
+    cutoffDate.setDate(cutoffDate.getDate() - DEVICE_INACTIVITY_DAYS);
 
     const result = await this.prisma.userDevice.deleteMany({
       where: {

--- a/apps/web/app/admin/students/[id]/page.tsx
+++ b/apps/web/app/admin/students/[id]/page.tsx
@@ -14,6 +14,7 @@ import {
     StudentWalletHistoryPopup,
     StudentWalletCard,
     StudentClassTuitionPopup,
+    StudentDevicePopup,
 } from "@/components/admin/student";
 import { UserLinkedProfileLinks } from "@/components/admin/user";
 import ParentReceiptEmailSwitch from "@/components/student/ParentReceiptEmailSwitch";
@@ -112,6 +113,7 @@ export default function AdminStudentDetailPage() {
     const [classesPopupOpen, setClassesPopupOpen] = useState(false);
     const [balancePopupMode, setBalancePopupMode] = useState<"topup" | "withdraw" | null>(null);
     const [walletHistoryOpen, setWalletHistoryOpen] = useState(false);
+    const [devicePopupOpen, setDevicePopupOpen] = useState(false);
     const [editingPackageForClassId, setEditingPackageForClassId] = useState<string | null>(null);
     const queryClient = useQueryClient();
     const { data: fullProfile } = useQuery({
@@ -473,6 +475,14 @@ export default function AdminStudentDetailPage() {
                     currentBalance={student.accountBalance ?? 0}
                 />
             ) : null}
+            {canManageStudent ? (
+                <StudentDevicePopup
+                    open={devicePopupOpen}
+                    onClose={() => setDevicePopupOpen(false)}
+                    studentId={student.id}
+                    studentName={student.fullName?.trim() || "Học sinh"}
+                />
+            ) : null}
             {canEditStudentClassTuition && editingPackageForClassId ? (() => {
                 const item = classItemsWithTuition.find((classItem) => classItem.classId === editingPackageForClassId);
 
@@ -590,6 +600,19 @@ export default function AdminStudentDetailPage() {
                                             >
                                                 <svg className="size-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
                                                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
+                                                </svg>
+                                            </button>
+                                        ) : null}
+                                        {canManageStudent ? (
+                                            <button
+                                                type="button"
+                                                onClick={() => setDevicePopupOpen(true)}
+                                                className="flex size-9 shrink-0 items-center justify-center rounded-full border border-border-default bg-bg-surface text-text-muted transition hover:bg-bg-tertiary hover:text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-border-focus focus-visible:ring-offset-2 focus-visible:ring-offset-bg-surface sm:size-8"
+                                                aria-label="Quản trị thiết bị"
+                                                title="Quản trị thiết bị"
+                                            >
+                                                <svg className="size-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
+                                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z" />
                                                 </svg>
                                             </button>
                                         ) : null}

--- a/apps/web/components/admin/student/StudentDevicePopup.tsx
+++ b/apps/web/components/admin/student/StudentDevicePopup.tsx
@@ -5,6 +5,11 @@ import { toast } from "sonner";
 import type { UserDevice } from "@/dtos/device.dto";
 import * as deviceApi from "@/lib/apis/device.api";
 import { cn } from "@/lib/utils";
+import {
+  ResponsiveDialog,
+  ResponsiveDialogBody,
+  ResponsiveActionFooter,
+} from "@/components/ui/ResponsiveDialog";
 
 type Props = {
   open: boolean;
@@ -109,113 +114,125 @@ export default function StudentDevicePopup({
   if (!open) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center">
-      <div
-        className="absolute inset-0 bg-black/50 backdrop-blur-sm"
-        onClick={onClose}
-      />
-      <div className="relative z-10 mx-4 w-full max-w-lg rounded-2xl bg-bg-primary shadow-xl">
-        <div className="flex items-center justify-between border-b border-border-default px-6 py-4">
-          <div>
-            <h2 className="text-lg font-semibold text-text-primary">
-              Quản trị thiết bị
-            </h2>
-            {studentName && (
-              <p className="text-sm text-text-secondary">{studentName}</p>
-            )}
-          </div>
-          <button
-            onClick={onClose}
-            className="rounded-lg p-2 text-text-muted transition-colors hover:bg-bg-tertiary hover:text-text-primary"
+    <ResponsiveDialog onBackdropClick={onClose} labelledBy="device-popup-title">
+      <div className="flex items-center justify-between border-b border-border-default px-6 py-4">
+        <div>
+          <h2
+            id="device-popup-title"
+            className="text-lg font-semibold text-text-primary"
           >
-            <svg className="size-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </button>
-        </div>
-
-        <div className="max-h-[60vh] overflow-y-auto px-6 py-4">
-          {isLoading && (
-            <div className="flex items-center justify-center py-8">
-              <div className="size-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
-            </div>
-          )}
-
-          {isError && (
-            <div className="rounded-lg bg-error/10 p-4 text-center text-sm text-error">
-              {getErrorMessage(error)}
-            </div>
-          )}
-
-          {devices && devices.length === 0 && (
-            <div className="py-8 text-center text-sm text-text-muted">
-              Học sinh chưa có thiết bị nào đăng nhập.
-            </div>
-          )}
-
-          {devices && devices.length > 0 && (
-            <div className="space-y-3">
-              {devices.map((device) => (
-                <div
-                  key={device.id}
-                  className={cn(
-                    "rounded-xl border p-4 transition-colors",
-                    device.isActive
-                      ? "border-success/30 bg-success/5"
-                      : "border-border-default bg-bg-secondary"
-                  )}
-                >
-                  <div className="flex items-start justify-between gap-3">
-                    <div className="min-w-0 flex-1">
-                      <div className="flex items-center gap-2">
-                        <span className="font-medium text-text-primary">
-                          {getDeviceLabel(device.deviceInfo)}
-                        </span>
-                        <span
-                          className={cn(
-                            "inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ring-1 ring-inset",
-                            getStatusBadgeClass(device)
-                          )}
-                        >
-                          {getStatusLabel(device)}
-                        </span>
-                      </div>
-                      <div className="mt-1 space-y-0.5 text-xs text-text-secondary">
-                        <p>IP: {device.ipAddress ?? "—"}</p>
-                        <p>Lần hoạt động cuối: {formatDateTime(device.lastActiveAt)}</p>
-                        <p>Đăng nhập lúc: {formatDate(device.createdAt)}</p>
-                        {device.daysSinceActive > 0 && (
-                          <p className="text-text-muted">
-                            {device.daysSinceActive} ngày chưa hoạt động
-                          </p>
-                        )}
-                      </div>
-                    </div>
-                    {device.isActive && (
-                      <button
-                        onClick={() => forceLogoutMutation.mutate(device.id)}
-                        disabled={forceLogoutMutation.isPending}
-                        className="shrink-0 rounded-lg bg-danger/10 px-3 py-1.5 text-xs font-medium text-danger transition-colors hover:bg-danger/20 disabled:opacity-50"
-                      >
-                        {forceLogoutMutation.isPending ? "Đang xử lý..." : "Buộc đăng xuất"}
-                      </button>
-                    )}
-                  </div>
-                </div>
-              ))}
-            </div>
+            Quản trị thiết bị
+          </h2>
+          {studentName && (
+            <p className="text-sm text-text-secondary">{studentName}</p>
           )}
         </div>
-
-        <div className="border-t border-border-default px-6 py-4">
-          <button
-            onClick={onClose}
-            className="w-full rounded-lg bg-bg-tertiary px-4 py-2.5 text-sm font-medium text-text-primary transition-colors hover:bg-bg-secondary"
+        <button
+          onClick={onClose}
+          className="rounded-lg p-2 text-text-muted transition-colors hover:bg-bg-tertiary hover:text-text-primary"
+        >
+          <svg
+            className="size-5"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
           >
-            Đóng
-          </button>
-        </div>
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M6 18L18 6M6 6l12 12"
+            />
+          </svg>
+        </button>
       </div>
-    </div>
+
+      <ResponsiveDialogBody>
+        {isLoading && (
+          <div className="flex items-center justify-center py-8">
+            <div className="size-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
+          </div>
+        )}
+
+        {isError && (
+          <div className="rounded-lg bg-error/10 p-4 text-center text-sm text-error">
+            {getErrorMessage(error)}
+          </div>
+        )}
+
+        {devices && devices.length === 0 && (
+          <div className="py-8 text-center text-sm text-text-muted">
+            Học sinh chưa có thiết bị nào đăng nhập.
+          </div>
+        )}
+
+        {devices && devices.length > 0 && (
+          <div className="space-y-3">
+            {devices.map((device) => (
+              <div
+                key={device.id}
+                className={cn(
+                  "rounded-xl border p-4 transition-colors",
+                  device.isActive
+                    ? "border-success/30 bg-success/5"
+                    : "border-border-default bg-bg-secondary",
+                )}
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <span className="font-medium text-text-primary">
+                        {getDeviceLabel(device.deviceInfo)}
+                      </span>
+                      <span
+                        className={cn(
+                          "inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ring-1 ring-inset",
+                          getStatusBadgeClass(device),
+                        )}
+                      >
+                        {getStatusLabel(device)}
+                      </span>
+                    </div>
+                    <div className="mt-1 space-y-0.5 text-xs text-text-secondary">
+                      <p>IP: {device.ipAddress ?? "—"}</p>
+                      <p>
+                        Lần hoạt động cuối:{" "}
+                        {formatDateTime(device.lastActiveAt)}
+                      </p>
+                      <p>Đăng nhập lúc: {formatDate(device.createdAt)}</p>
+                      {device.daysSinceActive > 0 && (
+                        <p className="text-text-muted">
+                          {device.daysSinceActive} ngày chưa hoạt động
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                  {device.isActive && (
+                    <button
+                      onClick={() => forceLogoutMutation.mutate(device.id)}
+                      disabled={forceLogoutMutation.isPending}
+                      className="shrink-0 rounded-lg bg-danger/10 px-3 py-1.5 text-xs font-medium text-danger transition-colors hover:bg-danger/20 disabled:opacity-50"
+                    >
+                      {forceLogoutMutation.isPending
+                        ? "Đang xử lý..."
+                        : "Buộc đăng xuất"}
+                    </button>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </ResponsiveDialogBody>
+
+      <ResponsiveActionFooter>
+        <button
+          onClick={onClose}
+          className="col-span-full rounded-lg bg-bg-tertiary px-4 py-2.5 text-sm font-medium text-text-primary transition-colors hover:bg-bg-secondary sm:col-span-1"
+        >
+          Đóng
+        </button>
+      </ResponsiveActionFooter>
+    </ResponsiveDialog>
   );
 }

--- a/apps/web/components/admin/student/StudentDevicePopup.tsx
+++ b/apps/web/components/admin/student/StudentDevicePopup.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import type { UserDevice } from "@/dtos/device.dto";
+import * as deviceApi from "@/lib/apis/device.api";
+import { cn } from "@/lib/utils";
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  studentId: string;
+  studentName?: string;
+};
+
+function formatDateTime(iso?: string | null): string {
+  if (!iso) return "—";
+  try {
+    return new Intl.DateTimeFormat("vi-VN", {
+      hour: "2-digit",
+      minute: "2-digit",
+      day: "2-digit",
+      month: "2-digit",
+      year: "numeric",
+    }).format(new Date(iso));
+  } catch {
+    return "—";
+  }
+}
+
+function formatDate(iso?: string | null): string {
+  if (!iso) return "—";
+  try {
+    return new Intl.DateTimeFormat("vi-VN", {
+      day: "2-digit",
+      month: "2-digit",
+      year: "numeric",
+    }).format(new Date(iso));
+  } catch {
+    return "—";
+  }
+}
+
+function getDeviceLabel(deviceInfo: Record<string, unknown> | null): string {
+  if (!deviceInfo) return "Thiết bị không xác định";
+  const platform = deviceInfo.platform as string;
+  const browser = deviceInfo.browser as string;
+  const os = deviceInfo.os as string;
+
+  if (platform) return platform;
+  if (browser && os) return `${browser} trên ${os}`;
+  if (browser) return browser;
+  if (os) return os;
+  return "Thiết bị không xác định";
+}
+
+function getStatusBadgeClass(device: UserDevice): string {
+  if (device.isActive) {
+    return "bg-success/10 text-success ring-success/20";
+  }
+  return "bg-bg-tertiary text-text-muted ring-border-default";
+}
+
+function getStatusLabel(device: UserDevice): string {
+  if (device.isActive) return "Đang hoạt động";
+  return "Đã hết hạn";
+}
+
+function getErrorMessage(error: unknown): string {
+  return (
+    (error as { response?: { data?: { message?: string } } })?.response?.data
+      ?.message ??
+    (error as Error)?.message ??
+    "Không thể tải danh sách thiết bị."
+  );
+}
+
+export default function StudentDevicePopup({
+  open,
+  onClose,
+  studentId,
+  studentName,
+}: Props) {
+  const queryClient = useQueryClient();
+
+  const {
+    data: devices,
+    isLoading,
+    isError,
+    error,
+  } = useQuery({
+    queryKey: ["student-devices", studentId],
+    queryFn: () => deviceApi.getStudentDevices(studentId, true),
+    enabled: open && !!studentId,
+    retry: false,
+  });
+
+  const forceLogoutMutation = useMutation({
+    mutationFn: deviceApi.forceLogoutDevice,
+    onSuccess: () => {
+      toast.success("Đã buộc đăng xuất thiết bị");
+      queryClient.invalidateQueries({ queryKey: ["student-devices", studentId] });
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || "Không thể buộc đăng xuất");
+    },
+  });
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div
+        className="absolute inset-0 bg-black/50 backdrop-blur-sm"
+        onClick={onClose}
+      />
+      <div className="relative z-10 mx-4 w-full max-w-lg rounded-2xl bg-bg-primary shadow-xl">
+        <div className="flex items-center justify-between border-b border-border-default px-6 py-4">
+          <div>
+            <h2 className="text-lg font-semibold text-text-primary">
+              Quản trị thiết bị
+            </h2>
+            {studentName && (
+              <p className="text-sm text-text-secondary">{studentName}</p>
+            )}
+          </div>
+          <button
+            onClick={onClose}
+            className="rounded-lg p-2 text-text-muted transition-colors hover:bg-bg-tertiary hover:text-text-primary"
+          >
+            <svg className="size-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <div className="max-h-[60vh] overflow-y-auto px-6 py-4">
+          {isLoading && (
+            <div className="flex items-center justify-center py-8">
+              <div className="size-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
+            </div>
+          )}
+
+          {isError && (
+            <div className="rounded-lg bg-error/10 p-4 text-center text-sm text-error">
+              {getErrorMessage(error)}
+            </div>
+          )}
+
+          {devices && devices.length === 0 && (
+            <div className="py-8 text-center text-sm text-text-muted">
+              Học sinh chưa có thiết bị nào đăng nhập.
+            </div>
+          )}
+
+          {devices && devices.length > 0 && (
+            <div className="space-y-3">
+              {devices.map((device) => (
+                <div
+                  key={device.id}
+                  className={cn(
+                    "rounded-xl border p-4 transition-colors",
+                    device.isActive
+                      ? "border-success/30 bg-success/5"
+                      : "border-border-default bg-bg-secondary"
+                  )}
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2">
+                        <span className="font-medium text-text-primary">
+                          {getDeviceLabel(device.deviceInfo)}
+                        </span>
+                        <span
+                          className={cn(
+                            "inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ring-1 ring-inset",
+                            getStatusBadgeClass(device)
+                          )}
+                        >
+                          {getStatusLabel(device)}
+                        </span>
+                      </div>
+                      <div className="mt-1 space-y-0.5 text-xs text-text-secondary">
+                        <p>IP: {device.ipAddress ?? "—"}</p>
+                        <p>Lần hoạt động cuối: {formatDateTime(device.lastActiveAt)}</p>
+                        <p>Đăng nhập lúc: {formatDate(device.createdAt)}</p>
+                        {device.daysSinceActive > 0 && (
+                          <p className="text-text-muted">
+                            {device.daysSinceActive} ngày chưa hoạt động
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                    {device.isActive && (
+                      <button
+                        onClick={() => forceLogoutMutation.mutate(device.id)}
+                        disabled={forceLogoutMutation.isPending}
+                        className="shrink-0 rounded-lg bg-danger/10 px-3 py-1.5 text-xs font-medium text-danger transition-colors hover:bg-danger/20 disabled:opacity-50"
+                      >
+                        {forceLogoutMutation.isPending ? "Đang xử lý..." : "Buộc đăng xuất"}
+                      </button>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div className="border-t border-border-default px-6 py-4">
+          <button
+            onClick={onClose}
+            className="w-full rounded-lg bg-bg-tertiary px-4 py-2.5 text-sm font-medium text-text-primary transition-colors hover:bg-bg-secondary"
+          >
+            Đóng
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/admin/student/index.ts
+++ b/apps/web/components/admin/student/index.ts
@@ -9,3 +9,4 @@ export { default as StudentBalancePopup } from "./StudentBalancePopup";
 export { default as StudentWalletHistoryPopup } from "./StudentWalletHistoryPopup";
 export { default as StudentExamCard } from "./StudentExamCard";
 export { default as StudentClassTuitionPopup } from "./StudentClassTuitionPopup";
+export { default as StudentDevicePopup } from "./StudentDevicePopup";

--- a/apps/web/dtos/device.dto.ts
+++ b/apps/web/dtos/device.dto.ts
@@ -1,0 +1,24 @@
+export interface UserDevice {
+  id: string;
+  userId: string;
+  tokenHash: string;
+  deviceInfo: Record<string, unknown> | null;
+  ipAddress: string | null;
+  lastActiveAt: string;
+  createdAt: string;
+  isActive: boolean;
+  isExpired: boolean;
+  daysSinceActive: number;
+}
+
+export interface DeviceListResponse {
+  devices: UserDevice[];
+}
+
+export interface ForceLogoutResponse {
+  message: string;
+}
+
+export interface CleanupExpiredResponse {
+  deletedCount: number;
+}

--- a/apps/web/lib/apis/device.api.ts
+++ b/apps/web/lib/apis/device.api.ts
@@ -1,0 +1,32 @@
+import { api } from "@/lib/client";
+import type { UserDevice, ForceLogoutResponse, CleanupExpiredResponse } from "@/dtos/device.dto";
+
+export async function getStudentDevices(
+  studentId: string,
+  includeExpired = false
+): Promise<UserDevice[]> {
+  const params = new URLSearchParams();
+  if (includeExpired) {
+    params.set("includeExpired", "true");
+  }
+  const queryString = params.toString();
+  const url = `/device/student/${studentId}${queryString ? `?${queryString}` : ""}`;
+  const response = await api.get<UserDevice[]>(url);
+  return response.data;
+}
+
+export async function forceLogoutDevice(
+  deviceId: string
+): Promise<ForceLogoutResponse> {
+  const response = await api.delete<ForceLogoutResponse>(
+    `/device/${deviceId}/force-logout`
+  );
+  return response.data;
+}
+
+export async function cleanupExpiredDevices(): Promise<CleanupExpiredResponse> {
+  const response = await api.delete<CleanupExpiredResponse>(
+    "/device/cleanup-expired"
+  );
+  return response.data;
+}

--- a/docs/Database Schema.md
+++ b/docs/Database Schema.md
@@ -82,6 +82,7 @@ Tài liệu này được tổng hợp trực tiếp từ Prisma schema tại `a
 ## 3) Quan hệ chính (high-level)
 
 - **User ↔ StudentInfo / StaffInfo**: quan hệ 1-0/1 qua `student_info.user_id` và `staff_info.user_id` (mỗi hồ sơ học sinh/nhân sự gắn tối đa một user, và mỗi user có tối đa một hồ sơ của từng loại).
+- **User → UserDevice**: 1-N qua `user_devices.user_id`, `onDelete: Cascade`.
 - **Class ↔ StaffInfo**: N-N qua `class_teachers`.
 - **Class ↔ StudentInfo**: N-N qua `student_classes`.
 - **Session → Class**: N-1 (`sessions.class_id`).


### PR DESCRIPTION
## What to build

Màn **19 (Quản trị thiết bị)**. Admin, CSKH và trợ lí xem được thiết bị hiện tại của một học sinh và **buộc đăng xuất** để giải phóng khi học sinh không tự đăng xuất được. Ghi vào lịch sử thao tác.

Kèm cơ chế tự giải phóng: thiết bị **không hoạt động 60 ngày** thì tự hết hiệu lực để tài khoản đăng nhập lại ở máy khác mà không cần ai can thiệp.

## Acceptance criteria

- [x] Xem thiết bị hiện tại của học sinh: máy gì, đăng nhập lúc nào, hoạt động lần cuối khi nào
- [x] Force-logout giải phóng thiết bị ngay
- [x] Ghi : ai làm, cho học sinh nào, lúc nào
- [x] Chỉ admin, CSKH, trợ lí làm được
- [x] Thiết bị quá 60 ngày không hoạt động tự hết hiệu lực
- [x] Mobile-first

## Changes

### Backend
- Added  table to Prisma schema for tracking login sessions
- Created  with service and controller:
  -  - List devices for a student
  -  - Force logout a device
  -  - Clean up expired devices (>60 days)
- Force-logout logs to  with 
- Only admin, customer_care, and assistant roles can access device management

### Frontend
- Created  component for viewing and force-logging out devices
- Added device management button to student detail page (next to edit button)
- Created DTOs and API client for device management

### Documentation
- Updated  with  table documentation

## Notes
- Auto-expiry: devices with  older than 60 days are considered expired
- Force-logout deletes the device record and logs the action
- Mobile-first design with responsive popup

Closes #67