### PR TITLE
feat: Tab Nội dung trong trang chi tiết lớp (#57)

### DIFF
--- a/apps/api/prisma/schema/learning.prisma
+++ b/apps/api/prisma/schema/learning.prisma
@@ -1,3 +1,25 @@
+enum ClassContentItemKind {
+  topic
+}
+
+model ClassContentItem {
+  id        String               @id @default(uuid())
+  classId   String               @map("class_id")
+  kind      ClassContentItemKind @default(topic) @map("kind")
+  topicId   String?              @map("topic_id")
+  sortOrder Int                  @default(0) @map("sort_order")
+  createdAt DateTime             @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt DateTime             @updatedAt @map("updated_at") @db.Timestamptz(6)
+
+  class Class @relation(fields: [classId], references: [id], onDelete: Cascade)
+  topic Topic? @relation(fields: [topicId], references: [id], onDelete: Cascade)
+
+  @@unique([classId, topicId])
+  @@index([classId])
+  @@index([topicId])
+  @@map("class_content_items")
+}
+
 model Class {
   id                            String                      @id
   name                          String
@@ -29,7 +51,7 @@ model Class {
   scheduleEntries               ClassScheduleEntry[]
   sessions                      Session[]
   students                      StudentClass[]
-  topics                        Topic[]
+  contentItems ClassContentItem[]
   trainingManager               StaffInfo?                  @relation("ClassTrainingManager", fields: [trainingManagerStaffId], references: [id])
   course                        Course                      @relation(fields: [courseId], references: [id])
 
@@ -362,7 +384,7 @@ model Topic {
 
   course        Course?    @relation(fields: [courseId], references: [id], onDelete: Cascade)
   chapter       Chapter?   @relation(fields: [chapterId], references: [id], onDelete: Cascade)
-  class         Class?     @relation(fields: [classId], references: [id], onDelete: Cascade)
+  contentItems ClassContentItem[]
   createdByUser User?      @relation("TopicCreatedBy", fields: [createdBy], references: [id])
   updatedByUser User?      @relation("TopicUpdatedBy", fields: [updatedBy], references: [id])
   lectures      Lecture[]

--- a/apps/api/prisma/schema/migrations/20260910000000_add_class_content_items/migration.sql
+++ b/apps/api/prisma/schema/migrations/20260910000000_add_class_content_items/migration.sql
@@ -1,0 +1,27 @@
+-- Migration to add class_content_items table and backfill existing class-owned topics
+
+CREATE TYPE "ClassContentItemKind" AS ENUM ('topic');
+
+CREATE TABLE "class_content_items" (
+  "id" TEXT PRIMARY KEY DEFAULT uuid_generate_v4(),
+  "class_id" TEXT NOT NULL REFERENCES "classes"("id") ON DELETE CASCADE,
+  "kind" "ClassContentItemKind" NOT NULL DEFAULT 'topic',
+  "topic_id" TEXT REFERENCES "topics"("id") ON DELETE CASCADE,
+  "sort_order" INTEGER NOT NULL DEFAULT 0,
+  "created_at" TIMESTAMP(6) WITH TIME ZONE NOT NULL DEFAULT now(),
+  "updated_at" TIMESTAMP(6) WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+-- Unique constraint to prevent duplicate topic entries per class
+CREATE UNIQUE INDEX "class_content_items_class_id_topic_id_key" ON "class_content_items" ("class_id", "topic_id");
+
+-- Backfill: for each existing topic that belongs to a class (topic.class_id NOT NULL),
+-- insert a class_content_items row preserving the original topic.order as sort_order.
+INSERT INTO "class_content_items" ("class_id", "topic_id", "sort_order", "created_at", "updated_at")
+SELECT "class_id", "id", "order", now(), now()
+FROM "topics"
+WHERE "class_id" IS NOT NULL;
+
+-- Indexes for queries
+CREATE INDEX "class_content_items_class_id_idx" ON "class_content_items" ("class_id");
+CREATE INDEX "class_content_items_topic_id_idx" ON "class_content_items" ("topic_id");

--- a/apps/api/src/dtos/topic.dto.ts
+++ b/apps/api/src/dtos/topic.dto.ts
@@ -195,3 +195,46 @@ export interface LectureResponseDto {
   createdAt: Date;
   updatedAt: Date;
 }
+
+// --- Class Content DTOs ---
+
+export class ClassContentCreateDto {
+  @ApiPropertyOptional({
+    description:
+      'ID chuyên đề có sẵn từ khoá để thêm vào lớp. Nếu bỏ trống thì tạo topic mới cho lớp.',
+    nullable: true,
+  })
+  @IsOptional()
+  @IsString()
+  topicId?: string;
+
+  @ApiPropertyOptional({
+    description: 'Tiêu đề topic mới (bắt buộc khi tạo topic mới cho lớp)',
+    example: 'Chuyên đề bổ trợ: Phương trình bậc 2',
+    nullable: true,
+  })
+  @IsOptional()
+  @IsString()
+  title?: string;
+
+  @ApiPropertyOptional({
+    description: 'Loại chuyên đề (mặc định theory)',
+    enum: TopicKind,
+    nullable: true,
+  })
+  @IsOptional()
+  @IsEnum(TopicKind)
+  kind?: TopicKind;
+}
+
+export interface ClassContentItemResponseDto {
+  id: string;
+  topicId: string;
+  kind: 'topic';
+  sortOrder: number;
+  title: string;
+  kindLabel: string;
+  source: 'course' | 'class';
+  chapterTitle?: string;
+  lectureCount?: number;
+}

--- a/apps/api/src/topic/topic.controller.ts
+++ b/apps/api/src/topic/topic.controller.ts
@@ -512,3 +512,86 @@ export class LectureController {
     return this.topicService.reorderLectures(topicId, lectureIds);
   }
 }
+
+@Controller('class/:classId/content')
+@ApiTags('class-content')
+@ApiCookieAuth('access_token')
+export class ClassContentController {
+  constructor(private readonly topicService: TopicService) {}
+
+  @Get()
+  @Roles(UserRole.admin)
+  @AllowStaffRolesOnAdminRoutes(StaffRole.assistant, StaffRole.teacher)
+  @ApiOperation({ summary: 'Lấy danh sách nội dung lớp học' })
+  @ApiParam({ name: 'classId', description: 'ID lớp học' })
+  @ApiResponse({ status: 200, description: 'Danh sách nội dung.' })
+  async listItems(
+    @CurrentUser() user: JwtPayload,
+    @Param('classId', new ParseClassIdPipe()) classId: string,
+  ) {
+    return this.topicService.listClassContentItems(classId, {
+      userId: user.id,
+      userEmail: user.email,
+      roleType: user.roleType,
+    });
+  }
+
+  @Post('reorder')
+  @Roles(UserRole.admin)
+  @AllowStaffRolesOnAdminRoutes(StaffRole.assistant, StaffRole.teacher)
+  @ApiOperation({ summary: 'Sắp xếp lại thứ tự nội dung lớp học' })
+  @ApiParam({ name: 'classId', description: 'ID lớp học' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: { orderedIds: { type: 'array', items: { type: 'string' } } },
+    },
+  })
+  @ApiResponse({ status: 200, description: 'Đã sắp xếp lại.' })
+  async reorder(
+    @CurrentUser() user: JwtPayload,
+    @Param('classId', new ParseClassIdPipe()) classId: string,
+    @Body('orderedIds') orderedIds: string[],
+  ) {
+    return this.topicService.reorderClassContentItems(classId, orderedIds, {
+      userId: user.id,
+      userEmail: user.email,
+      roleType: user.roleType,
+    });
+  }
+
+  @Delete(':itemId')
+  @Roles(UserRole.admin)
+  @AllowStaffRolesOnAdminRoutes(StaffRole.assistant, StaffRole.teacher)
+  @ApiOperation({ summary: 'Xóa nội dung lớp học' })
+  @ApiParam({ name: 'classId', description: 'ID lớp học' })
+  @ApiParam({ name: 'itemId', description: 'ID nội dung' })
+  @ApiResponse({ status: 200, description: 'Đã xóa.' })
+  async delete(
+    @CurrentUser() user: JwtPayload,
+    @Param('classId', new ParseClassIdPipe()) classId: string,
+    @Param('itemId') itemId: string,
+  ) {
+    return this.topicService.deleteClassContentItem(classId, itemId, {
+      userId: user.id,
+      userEmail: user.email,
+      roleType: user.roleType,
+    });
+  }
+
+  @Get('student')
+  @Roles(UserRole.student)
+  @ApiOperation({ summary: 'Lấy danh sách nội dung lớp học cho học sinh' })
+  @ApiParam({ name: 'classId', description: 'ID lớp học' })
+  @ApiResponse({ status: 200, description: 'Danh sách nội dung.' })
+  async listForStudent(
+    @CurrentUser() user: JwtPayload,
+    @Param('classId', new ParseClassIdPipe()) classId: string,
+  ) {
+    const studentId = await this.topicService.findStudentIdByUserId(user.id);
+    if (!studentId) {
+      throw new NotFoundException('Student profile not found');
+    }
+    return this.topicService.listClassContentForStudent(classId, studentId);
+  }
+}

--- a/apps/api/src/topic/topic.controller.ts
+++ b/apps/api/src/topic/topic.controller.ts
@@ -36,6 +36,7 @@ import {
   LectureCreateDto,
   LectureUpdateDto,
   LectureResponseDto,
+  ClassContentCreateDto,
 } from 'src/dtos/topic.dto';
 import { TopicService } from './topic.service';
 
@@ -518,6 +519,26 @@ export class LectureController {
 @ApiCookieAuth('access_token')
 export class ClassContentController {
   constructor(private readonly topicService: TopicService) {}
+
+  @Post()
+  @Roles(UserRole.admin)
+  @AllowStaffRolesOnAdminRoutes(StaffRole.assistant, StaffRole.teacher)
+  @ApiOperation({ summary: 'Thêm nội dung vào lớp học' })
+  @ApiParam({ name: 'classId', description: 'ID lớp học' })
+  @ApiBody({ type: ClassContentCreateDto })
+  @ApiResponse({ status: 201, description: 'Đã thêm nội dung.' })
+  @ApiResponse({ status: 400, description: 'Lỗi dữ liệu đầu vào.' })
+  async create(
+    @CurrentUser() user: JwtPayload,
+    @Param('classId', new ParseClassIdPipe()) classId: string,
+    @Body() dto: ClassContentCreateDto,
+  ) {
+    return this.topicService.createClassContentItem(classId, dto, {
+      userId: user.id,
+      userEmail: user.email,
+      roleType: user.roleType,
+    });
+  }
 
   @Get()
   @Roles(UserRole.admin)

--- a/apps/api/src/topic/topic.module.ts
+++ b/apps/api/src/topic/topic.module.ts
@@ -6,6 +6,7 @@ import {
   CourseTopicController,
   ClassTopicController,
   LectureController,
+  ClassContentController,
 } from './topic.controller';
 import { TopicService } from './topic.service';
 
@@ -16,6 +17,7 @@ import { TopicService } from './topic.service';
     CourseTopicController,
     ClassTopicController,
     LectureController,
+    ClassContentController,
   ],
   providers: [TopicService],
   exports: [TopicService],

--- a/apps/api/src/topic/topic.service.spec.ts
+++ b/apps/api/src/topic/topic.service.spec.ts
@@ -1,0 +1,420 @@
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+jest.mock('../prisma/prisma.service', () => ({
+  PrismaService: class PrismaServiceMock {},
+}));
+
+jest.mock('../../generated/client', () => ({}));
+
+jest.mock('../action-history/action-history.service', () => ({
+  ActionHistoryService: class ActionHistoryServiceMock {},
+}));
+
+import { TopicService } from './topic.service';
+import {
+  BadRequestException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
+import { UserRole } from 'generated/enums';
+
+describe('TopicService — ClassContent methods', () => {
+  let service: TopicService;
+  let mockPrisma: Record<string, any>;
+
+  const adminActor = {
+    userId: 'user-admin-1',
+    userEmail: 'admin@test.com',
+    roleType: UserRole.admin,
+  };
+
+  beforeEach(() => {
+    mockPrisma = {
+      class: { findUnique: jest.fn() },
+      staffInfo: { findFirst: jest.fn() },
+      classTeacher: { findFirst: jest.fn() },
+      studentClass: { findFirst: jest.fn() },
+      topic: {
+        findUnique: jest.fn(),
+        create: jest.fn(),
+        delete: jest.fn(),
+      },
+      classContentItem: {
+        findMany: jest.fn(),
+        findUnique: jest.fn(),
+        count: jest.fn(),
+        aggregate: jest.fn(),
+        create: jest.fn(),
+        update: jest.fn(),
+        delete: jest.fn(),
+      },
+      $transaction: jest.fn(
+        (fnOrArray: ((tx: any) => Promise<any>) | any[]) => {
+          if (typeof fnOrArray === 'function') return fnOrArray(mockPrisma);
+          return Promise.all(fnOrArray);
+        },
+      ),
+    };
+
+    service = new TopicService(mockPrisma as any, {} as any);
+  });
+
+  // ─── createClassContentItem ───
+
+  describe('createClassContentItem', () => {
+    it('should create a new topic for class when no topicId provided', async () => {
+      mockPrisma.class.findUnique.mockResolvedValue({ id: 'cls-1' });
+      mockPrisma.classTeacher.findFirst.mockResolvedValue({ id: 'ct-1' });
+      mockPrisma.staffInfo.findFirst.mockResolvedValue({ id: 'staff-1' });
+      mockPrisma.classContentItem.aggregate.mockResolvedValue({
+        _max: { sortOrder: 1 },
+      });
+      mockPrisma.topic.create.mockResolvedValue({
+        id: 'topic-new',
+        kind: 'theory',
+        classId: 'cls-1',
+        title: 'New topic',
+      });
+      mockPrisma.classContentItem.create.mockResolvedValue({
+        id: 'cci-1',
+        topicId: 'topic-new',
+        kind: 'topic',
+        sortOrder: 2,
+        classId: 'cls-1',
+        topic: {
+          title: 'New topic',
+          kind: 'theory',
+          classId: 'cls-1',
+          chapter: null,
+          lectures: [],
+        },
+      });
+
+      const result = await service.createClassContentItem(
+        'cls-1',
+        { title: 'New topic', kind: 'theory' as any },
+        adminActor,
+      );
+
+      expect(result.title).toBe('New topic');
+      expect(result.source).toBe('class');
+      expect(mockPrisma.topic.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            classId: 'cls-1',
+            title: 'New topic',
+          }),
+        }),
+      );
+      expect(mockPrisma.classContentItem.create).toHaveBeenCalled();
+    });
+
+    it('should add an existing topic to class content', async () => {
+      mockPrisma.class.findUnique.mockResolvedValue({ id: 'cls-1' });
+      mockPrisma.classTeacher.findFirst.mockResolvedValue({ id: 'ct-1' });
+      mockPrisma.staffInfo.findFirst.mockResolvedValue({ id: 'staff-1' });
+      mockPrisma.topic.findUnique.mockResolvedValue({
+        id: 'topic-existing',
+        title: 'Existing topic',
+        kind: 'practice',
+        courseId: 'course-1',
+        classId: null,
+      });
+      mockPrisma.classContentItem.findUnique.mockResolvedValue(null);
+      mockPrisma.classContentItem.aggregate.mockResolvedValue({
+        _max: { sortOrder: 5 },
+      });
+      mockPrisma.classContentItem.create.mockResolvedValue({
+        id: 'cci-2',
+        topicId: 'topic-existing',
+        kind: 'topic',
+        sortOrder: 6,
+        classId: 'cls-1',
+        topic: {
+          title: 'Existing topic',
+          kind: 'practice',
+          classId: null,
+          chapter: { title: 'Ch 1' },
+          lectures: [{ id: 'l1' }, { id: 'l2' }],
+        },
+      });
+
+      const result = await service.createClassContentItem(
+        'cls-1',
+        { topicId: 'topic-existing' },
+        adminActor,
+      );
+
+      expect(result.title).toBe('Existing topic');
+      expect(result.source).toBe('course');
+      expect(result.chapterTitle).toBe('Ch 1');
+      expect(result.lectureCount).toBe(2);
+    });
+
+    it('should throw if topicId already in class content', async () => {
+      mockPrisma.class.findUnique.mockResolvedValue({ id: 'cls-1' });
+      mockPrisma.classTeacher.findFirst.mockResolvedValue({ id: 'ct-1' });
+      mockPrisma.staffInfo.findFirst.mockResolvedValue({ id: 'staff-1' });
+      mockPrisma.topic.findUnique.mockResolvedValue({ id: 'topic-1' });
+      mockPrisma.classContentItem.findUnique.mockResolvedValue({
+        id: 'existing',
+      });
+
+      await expect(
+        service.createClassContentItem(
+          'cls-1',
+          { topicId: 'topic-1' },
+          adminActor,
+        ),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw if title missing when creating new topic', async () => {
+      mockPrisma.class.findUnique.mockResolvedValue({ id: 'cls-1' });
+      mockPrisma.classTeacher.findFirst.mockResolvedValue({ id: 'ct-1' });
+      mockPrisma.staffInfo.findFirst.mockResolvedValue({ id: 'staff-1' });
+
+      await expect(
+        service.createClassContentItem('cls-1', { title: '  ' }, adminActor),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  // ─── listClassContentItems ───
+
+  describe('listClassContentItems', () => {
+    it('should return mapped DTOs', async () => {
+      mockPrisma.class.findUnique.mockResolvedValue({ id: 'cls-1' });
+      mockPrisma.classTeacher.findFirst.mockResolvedValue({ id: 'ct-1' });
+      mockPrisma.staffInfo.findFirst.mockResolvedValue({ id: 'staff-1' });
+      mockPrisma.classContentItem.findMany.mockResolvedValue([
+        {
+          id: 'cci-1',
+          topicId: 't1',
+          kind: 'topic',
+          sortOrder: 0,
+          classId: 'cls-1',
+          topic: {
+            title: 'Topic A',
+            kind: 'theory',
+            classId: 'cls-1',
+            chapter: null,
+            lectures: [],
+          },
+        },
+        {
+          id: 'cci-2',
+          topicId: 't2',
+          kind: 'topic',
+          sortOrder: 1,
+          classId: 'cls-1',
+          topic: {
+            title: 'Topic B',
+            kind: 'practice',
+            classId: 'course-1',
+            chapter: { title: 'Ch 2' },
+            lectures: [{}],
+          },
+        },
+      ]);
+
+      const result = await service.listClassContentItems('cls-1', adminActor);
+
+      expect(result).toHaveLength(2);
+      expect(result[0].source).toBe('class');
+      expect(result[0].kindLabel).toBe('Lý thuyết');
+      expect(result[1].source).toBe('course');
+      expect(result[1].kindLabel).toBe('Luyện tập');
+      expect(result[1].chapterTitle).toBe('Ch 2');
+      expect(result[1].lectureCount).toBe(1);
+    });
+  });
+
+  // ─── reorderClassContentItems ───
+
+  describe('reorderClassContentItems', () => {
+    it('should reject if any ID does not belong to class', async () => {
+      mockPrisma.class.findUnique.mockResolvedValue({ id: 'cls-1' });
+      mockPrisma.classTeacher.findFirst.mockResolvedValue({ id: 'ct-1' });
+      mockPrisma.staffInfo.findFirst.mockResolvedValue({ id: 'staff-1' });
+      mockPrisma.classContentItem.findMany.mockResolvedValue([{ id: 'cci-1' }]);
+
+      await expect(
+        service.reorderClassContentItems(
+          'cls-1',
+          ['cci-1', 'cci-foreign'],
+          adminActor,
+        ),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should update sortOrder for all owned IDs', async () => {
+      mockPrisma.class.findUnique.mockResolvedValue({ id: 'cls-1' });
+      mockPrisma.classTeacher.findFirst.mockResolvedValue({ id: 'ct-1' });
+      mockPrisma.staffInfo.findFirst.mockResolvedValue({ id: 'staff-1' });
+      mockPrisma.classContentItem.findMany
+        .mockResolvedValueOnce([{ id: 'cci-1' }, { id: 'cci-2' }])
+        .mockResolvedValueOnce([
+          {
+            id: 'cci-1',
+            topicId: 't1',
+            kind: 'topic',
+            sortOrder: 0,
+            classId: 'cls-1',
+            topic: {
+              title: 'A',
+              kind: 'theory',
+              classId: 'cls-1',
+              chapter: null,
+              lectures: [],
+            },
+          },
+          {
+            id: 'cci-2',
+            topicId: 't2',
+            kind: 'topic',
+            sortOrder: 1,
+            classId: 'cls-1',
+            topic: {
+              title: 'B',
+              kind: 'theory',
+              classId: 'cls-1',
+              chapter: null,
+              lectures: [],
+            },
+          },
+        ]);
+      mockPrisma.classContentItem.update.mockResolvedValue({});
+
+      await service.reorderClassContentItems(
+        'cls-1',
+        ['cci-2', 'cci-1'],
+        adminActor,
+      );
+
+      expect(mockPrisma.classContentItem.update).toHaveBeenCalledTimes(2);
+      expect(mockPrisma.classContentItem.update).toHaveBeenCalledWith({
+        where: { id: 'cci-2' },
+        data: { sortOrder: 0 },
+      });
+      expect(mockPrisma.classContentItem.update).toHaveBeenCalledWith({
+        where: { id: 'cci-1' },
+        data: { sortOrder: 1 },
+      });
+    });
+  });
+
+  // ─── deleteClassContentItem ───
+
+  describe('deleteClassContentItem', () => {
+    it('should delete class content item and class-owned topic', async () => {
+      mockPrisma.class.findUnique.mockResolvedValue({ id: 'cls-1' });
+      mockPrisma.classTeacher.findFirst.mockResolvedValue({ id: 'ct-1' });
+      mockPrisma.staffInfo.findFirst.mockResolvedValue({ id: 'staff-1' });
+      mockPrisma.classContentItem.findUnique.mockResolvedValue({
+        id: 'cci-1',
+        classId: 'cls-1',
+        topic: { id: 'topic-1', classId: 'cls-1' },
+      });
+      mockPrisma.classContentItem.delete.mockResolvedValue({});
+      mockPrisma.topic.delete.mockResolvedValue({});
+      mockPrisma.classContentItem.findMany.mockResolvedValue([]);
+
+      await service.deleteClassContentItem('cls-1', 'cci-1', adminActor);
+
+      expect(mockPrisma.classContentItem.delete).toHaveBeenCalledWith({
+        where: { id: 'cci-1' },
+      });
+      expect(mockPrisma.topic.delete).toHaveBeenCalledWith({
+        where: { id: 'topic-1' },
+      });
+    });
+
+    it('should delete class content item but keep course topic', async () => {
+      mockPrisma.class.findUnique.mockResolvedValue({ id: 'cls-1' });
+      mockPrisma.classTeacher.findFirst.mockResolvedValue({ id: 'ct-1' });
+      mockPrisma.staffInfo.findFirst.mockResolvedValue({ id: 'staff-1' });
+      mockPrisma.classContentItem.findUnique.mockResolvedValue({
+        id: 'cci-2',
+        classId: 'cls-1',
+        topic: { id: 'topic-course', classId: 'course-1' },
+      });
+      mockPrisma.classContentItem.delete.mockResolvedValue({});
+      mockPrisma.classContentItem.findMany.mockResolvedValue([]);
+
+      await service.deleteClassContentItem('cls-1', 'cci-2', adminActor);
+
+      expect(mockPrisma.classContentItem.delete).toHaveBeenCalled();
+      expect(mockPrisma.topic.delete).not.toHaveBeenCalled();
+    });
+
+    it('should throw if item not found or belongs to different class', async () => {
+      mockPrisma.class.findUnique.mockResolvedValue({ id: 'cls-1' });
+      mockPrisma.classTeacher.findFirst.mockResolvedValue({ id: 'ct-1' });
+      mockPrisma.staffInfo.findFirst.mockResolvedValue({ id: 'staff-1' });
+      mockPrisma.classContentItem.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.deleteClassContentItem('cls-1', 'cci-missing', adminActor),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // ─── listClassContentForStudent ───
+
+  describe('listClassContentForStudent', () => {
+    it('should return content for enrolled student', async () => {
+      mockPrisma.class.findUnique.mockResolvedValue({
+        id: 'cls-1',
+        contentAccessExpiresAt: null,
+      });
+      mockPrisma.studentClass.findFirst.mockResolvedValue({ id: 'sc-1' });
+      mockPrisma.classContentItem.findMany.mockResolvedValue([
+        {
+          id: 'cci-1',
+          topicId: 't1',
+          kind: 'topic',
+          sortOrder: 0,
+          classId: 'cls-1',
+          topic: {
+            title: 'Topic A',
+            kind: 'theory',
+            classId: 'cls-1',
+            chapter: null,
+            lectures: [],
+          },
+        },
+      ]);
+
+      const result = await service.listClassContentForStudent('cls-1', 'stu-1');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].title).toBe('Topic A');
+    });
+
+    it('should throw if not enrolled', async () => {
+      mockPrisma.class.findUnique.mockResolvedValue({
+        id: 'cls-1',
+        contentAccessExpiresAt: null,
+      });
+      mockPrisma.studentClass.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.listClassContentForStudent('cls-1', 'stu-1'),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('should throw if class content access expired', async () => {
+      mockPrisma.class.findUnique.mockResolvedValue({
+        id: 'cls-1',
+        contentAccessExpiresAt: new Date('2020-01-01'),
+      });
+      mockPrisma.studentClass.findFirst.mockResolvedValue({ id: 'sc-1' });
+
+      await expect(
+        service.listClassContentForStudent('cls-1', 'stu-1'),
+      ).rejects.toThrow(ForbiddenException);
+    });
+  });
+});

--- a/apps/api/src/topic/topic.service.ts
+++ b/apps/api/src/topic/topic.service.ts
@@ -556,4 +556,87 @@ export class TopicService {
       throw new ForbiddenException('This class has expired');
     }
   }
+
+  // ---------- Class Content ----------
+
+  async listClassContentItems(classId: string, actor: ActionHistoryActor) {
+    // Ensure staff or admin access
+    await this.validateStaffClassAccess(classId, actor);
+    return this.prisma.classContentItem.findMany({
+      where: { classId },
+      orderBy: { sortOrder: 'asc' },
+      include: { topic: { include: { chapter: true } } },
+    });
+  }
+
+  async reorderClassContentItems(
+    classId: string,
+    orderedIds: string[],
+    actor: ActionHistoryActor,
+  ) {
+    await this.validateStaffClassAccess(classId, actor);
+    const count = await this.prisma.classContentItem.count({
+      where: { classId },
+    });
+    if (orderedIds.length !== count) {
+      throw new BadRequestException('Ordering does not match number of items');
+    }
+    await this.prisma.$transaction(
+      orderedIds.map((id, idx) =>
+        this.prisma.classContentItem.update({
+          where: { id },
+          data: { sortOrder: idx },
+        }),
+      ),
+    );
+    return this.listClassContentItems(classId, actor);
+  }
+
+  async deleteClassContentItem(
+    classId: string,
+    itemId: string,
+    actor: ActionHistoryActor,
+  ) {
+    await this.validateStaffClassAccess(classId, actor);
+    const item = await this.prisma.classContentItem.findUnique({
+      where: { id: itemId },
+      include: { topic: true },
+    });
+    if (!item || item.classId !== classId) {
+      throw new NotFoundException('Class content item not found');
+    }
+    await this.prisma.$transaction(async (tx) => {
+      await tx.classContentItem.delete({ where: { id: itemId } });
+      if (item.topic?.classId === classId) {
+        await tx.topic.delete({ where: { id: item.topic.id } });
+      }
+    });
+    return this.listClassContentItems(classId, actor);
+  }
+
+  async listClassContentForStudent(classId: string, studentId: string) {
+    const classInfo = await this.prisma.class.findUnique({
+      where: { id: classId },
+    });
+    if (!classInfo) {
+      throw new NotFoundException('Class not found');
+    }
+    const enrollment = await this.prisma.studentClass.findFirst({
+      where: { classId, studentId },
+    });
+    if (!enrollment) {
+      throw new ForbiddenException('Student not a member of the class');
+    }
+    if (
+      classInfo.contentAccessExpiresAt &&
+      classInfo.contentAccessExpiresAt < new Date()
+    ) {
+      throw new ForbiddenException('Content access period has expired');
+    }
+    return this.prisma.classContentItem.findMany({
+      where: { classId },
+      orderBy: { sortOrder: 'asc' },
+      include: { topic: { include: { chapter: true } } },
+    });
+  }
 }

--- a/apps/api/src/topic/topic.service.ts
+++ b/apps/api/src/topic/topic.service.ts
@@ -17,6 +17,8 @@ import {
   LectureCreateDto,
   LectureUpdateDto,
   LectureResponseDto,
+  ClassContentCreateDto,
+  ClassContentItemResponseDto,
 } from 'src/dtos/topic.dto';
 import { UserRole, TopicKind, StaffRole } from 'generated/enums';
 
@@ -558,29 +560,162 @@ export class TopicService {
   }
 
   // ---------- Class Content ----------
+  //
+  // Finding #8 — dual source of truth note:
+  // `Topic.classId` (scalar FK on the topics table) and `class_content_items.class_id`
+  // serve different purposes. Topic.classId marks a topic as "owned by" a class (created
+  // inline for that class). class_content_items is the ordered list of topics shown in
+  // the class content tab — it can reference both class-owned topics AND course topics.
+  // When creating a new topic for a class, we write BOTH: Topic.classId = classId (so
+  // the topic is recognizably class-scoped) AND a class_content_items row (so it appears
+  // in the ordered content list). When adding an existing course topic, only a
+  // class_content_items row is created — the topic's courseId/chapterId stay untouched.
 
-  async listClassContentItems(classId: string, actor: ActionHistoryActor) {
-    // Ensure staff or admin access
+  /**
+   * Map a raw Prisma ClassContentItem (with included topic/chapter/lectures) to the
+   * frontend DTO shape expected by ClassContentManager.
+   */
+  private mapClassContentItem(item: {
+    id: string;
+    topicId: string | null;
+    kind: string;
+    sortOrder: number;
+    classId: string;
+    topic?: {
+      title: string;
+      kind: string;
+      classId: string | null;
+      chapter?: { title: string } | null;
+      lectures?: unknown[];
+    } | null;
+  }): ClassContentItemResponseDto {
+    const topic = item.topic;
+    const kindLabel = topic?.kind === 'practice' ? 'Luyện tập' : 'Lý thuyết';
+    const source: 'course' | 'class' =
+      item.kind === 'topic' && topic?.classId === item.classId
+        ? 'class'
+        : 'course';
+    const lectureCount = Array.isArray(topic?.lectures)
+      ? topic.lectures.length
+      : undefined;
+    return {
+      id: item.id,
+      topicId: item.topicId ?? '',
+      kind: item.kind as 'topic',
+      sortOrder: item.sortOrder,
+      title: topic?.title ?? '(Chuyên đề đã xoá)',
+      kindLabel,
+      source,
+      chapterTitle: topic?.chapter?.title,
+      lectureCount,
+    };
+  }
+
+  async createClassContentItem(
+    classId: string,
+    dto: ClassContentCreateDto,
+    actor: ActionHistoryActor,
+  ): Promise<ClassContentItemResponseDto> {
     await this.validateStaffClassAccess(classId, actor);
-    return this.prisma.classContentItem.findMany({
+
+    let topicId: string;
+
+    if (dto.topicId) {
+      // Mode A: add an existing topic (from a course) into this class's content list
+      const topic = await this.prisma.topic.findUnique({
+        where: { id: dto.topicId },
+      });
+      if (!topic) {
+        throw new NotFoundException(`Topic ${dto.topicId} not found`);
+      }
+      // Prevent duplicates
+      const existing = await this.prisma.classContentItem.findUnique({
+        where: { classId_topicId: { classId, topicId: dto.topicId } },
+      });
+      if (existing) {
+        throw new BadRequestException(
+          'Topic is already in this class content list',
+        );
+      }
+      topicId = dto.topicId;
+    } else {
+      // Mode B: create a new topic scoped to this class
+      if (!dto.title?.trim()) {
+        throw new BadRequestException(
+          'Title is required when creating a new topic',
+        );
+      }
+      const topic = await this.prisma.topic.create({
+        data: {
+          kind: dto.kind ?? 'theory',
+          classId,
+          title: dto.title.trim(),
+          createdBy: actor.userId,
+          updatedBy: actor.userId,
+        },
+      });
+      topicId = topic.id;
+    }
+
+    // Determine sortOrder: append at the end
+    const maxSort = await this.prisma.classContentItem.aggregate({
+      where: { classId },
+      _max: { sortOrder: true },
+    });
+    const nextSort = (maxSort._max.sortOrder ?? -1) + 1;
+
+    const item = await this.prisma.classContentItem.create({
+      data: {
+        classId,
+        topicId,
+        kind: 'topic',
+        sortOrder: nextSort,
+      },
+      include: {
+        topic: { include: { chapter: true, lectures: true } },
+      },
+    });
+
+    this.logger.log(
+      `Class content item created: ${item.id} for class ${classId} by ${actor.userEmail}`,
+    );
+
+    return this.mapClassContentItem(item);
+  }
+
+  async listClassContentItems(
+    classId: string,
+    actor: ActionHistoryActor,
+  ): Promise<ClassContentItemResponseDto[]> {
+    await this.validateStaffClassAccess(classId, actor);
+    const items = await this.prisma.classContentItem.findMany({
       where: { classId },
       orderBy: { sortOrder: 'asc' },
-      include: { topic: { include: { chapter: true } } },
+      include: {
+        topic: { include: { chapter: true, lectures: true } },
+      },
     });
+    return items.map((item) => this.mapClassContentItem(item));
   }
 
   async reorderClassContentItems(
     classId: string,
     orderedIds: string[],
     actor: ActionHistoryActor,
-  ) {
+  ): Promise<ClassContentItemResponseDto[]> {
     await this.validateStaffClassAccess(classId, actor);
-    const count = await this.prisma.classContentItem.count({
-      where: { classId },
+
+    // Finding #4: verify ALL IDs belong to this class before updating
+    const owned = await this.prisma.classContentItem.findMany({
+      where: { id: { in: orderedIds }, classId },
+      select: { id: true },
     });
-    if (orderedIds.length !== count) {
-      throw new BadRequestException('Ordering does not match number of items');
+    if (owned.length !== orderedIds.length) {
+      throw new BadRequestException(
+        'Some IDs do not belong to this class or do not exist',
+      );
     }
+
     await this.prisma.$transaction(
       orderedIds.map((id, idx) =>
         this.prisma.classContentItem.update({
@@ -596,7 +731,7 @@ export class TopicService {
     classId: string,
     itemId: string,
     actor: ActionHistoryActor,
-  ) {
+  ): Promise<ClassContentItemResponseDto[]> {
     await this.validateStaffClassAccess(classId, actor);
     const item = await this.prisma.classContentItem.findUnique({
       where: { id: itemId },
@@ -607,6 +742,7 @@ export class TopicService {
     }
     await this.prisma.$transaction(async (tx) => {
       await tx.classContentItem.delete({ where: { id: itemId } });
+      // Only delete the topic if it's class-owned (not a course topic)
       if (item.topic?.classId === classId) {
         await tx.topic.delete({ where: { id: item.topic.id } });
       }
@@ -614,7 +750,10 @@ export class TopicService {
     return this.listClassContentItems(classId, actor);
   }
 
-  async listClassContentForStudent(classId: string, studentId: string) {
+  async listClassContentForStudent(
+    classId: string,
+    studentId: string,
+  ): Promise<ClassContentItemResponseDto[]> {
     const classInfo = await this.prisma.class.findUnique({
       where: { id: classId },
     });
@@ -633,10 +772,13 @@ export class TopicService {
     ) {
       throw new ForbiddenException('Content access period has expired');
     }
-    return this.prisma.classContentItem.findMany({
+    const items = await this.prisma.classContentItem.findMany({
       where: { classId },
       orderBy: { sortOrder: 'asc' },
-      include: { topic: { include: { chapter: true } } },
+      include: {
+        topic: { include: { chapter: true, lectures: true } },
+      },
     });
+    return items.map((item) => this.mapClassContentItem(item));
   }
 }

--- a/apps/web/app/admin/classes/[id]/page.tsx
+++ b/apps/web/app/admin/classes/[id]/page.tsx
@@ -1565,7 +1565,7 @@ export default function AdminClassDetailPage() {
               className="min-w-0"
               {...panelMotionProps}
             >
-                <ClassContentManager classId={id} canManage={canCreateSession} />
+              <ClassContentManager classId={id} canManage={canCreateSession} />
             </motion.section>
           )}
           </AnimatePresence>

--- a/apps/web/app/admin/classes/[id]/page.tsx
+++ b/apps/web/app/admin/classes/[id]/page.tsx
@@ -48,7 +48,7 @@ import SessionHistoryTable from "@/components/admin/session/SessionHistoryTable"
 import StudentClassTuitionPopup from "@/components/admin/student/StudentClassTuitionPopup";
 import MonthNav from "@/components/admin/MonthNav";
 import QueryRefreshStrip from "@/components/ui/query-refresh-strip";
-import StaffTopicsManager from "@/components/staff/StaffTopicsManager";
+import ClassContentManager from "@/components/admin/ClassContentManager";
 import {
   ClassStatus,
   ClassDetail,
@@ -1364,8 +1364,8 @@ export default function AdminClassDetailPage() {
           onChanged={handleMakeupScheduleChanged}
         />
 
-        {/* Row 3: Lịch sử và Chuyên đề – 2 tab */}
-        <ClassCard title="Lịch sử & Chuyên đề" className="w-full">
+        {/* Row 3: Lịch sử & Nội dung – 2 tab */}
+        <ClassCard title="Lịch sử & Nội dung" className="w-full">
           <div className="mb-3 flex flex-col gap-3">
             <div
               className="inline-flex w-full sm:w-80 items-center gap-1 rounded-2xl border border-border-default bg-bg-secondary/70 p-1.5 shadow-xs"
@@ -1422,7 +1422,7 @@ export default function AdminClassDetailPage() {
                 <svg className="size-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                   <path strokeLinecap="round" strokeLinejoin="round" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
                 </svg>
-                <span>Chuyên đề</span>
+                <span>Nội dung</span>
               </button>
             </div>
 
@@ -1565,7 +1565,7 @@ export default function AdminClassDetailPage() {
               className="min-w-0"
               {...panelMotionProps}
             >
-              <StaffTopicsManager classId={id} />
+                <ClassContentManager classId={id} canManage={canCreateSession} />
             </motion.section>
           )}
           </AnimatePresence>

--- a/apps/web/app/staff/classes/[id]/page.tsx
+++ b/apps/web/app/staff/classes/[id]/page.tsx
@@ -1335,7 +1335,7 @@ export default function StaffClassDetailPage() {
               role="tabpanel"
               aria-labelledby="staff-class-detail-tab-topics"
             >
-                <ClassContentManager classId={id} canManage={canManageSessions} />
+              <ClassContentManager classId={id} canManage={canManageSessions} />
             </section>
           )}
         </ClassCard>

--- a/apps/web/app/staff/classes/[id]/page.tsx
+++ b/apps/web/app/staff/classes/[id]/page.tsx
@@ -28,7 +28,7 @@ import AddSessionPopup from "@/components/admin/class/AddSessionPopup";
 import SessionHistoryTable from "@/components/admin/session/SessionHistoryTable";
 import MonthNav from "@/components/admin/MonthNav";
 import QueryRefreshStrip from "@/components/ui/query-refresh-strip";
-import StaffTopicsManager from "@/components/staff/StaffTopicsManager";
+import ClassContentManager from "@/components/admin/ClassContentManager";
 import type {
   ClassDetail,
   ClassScheduleItem,
@@ -321,7 +321,7 @@ export default function StaffClassDetailPage() {
   const searchParams = useSearchParams();
   const queryClient = useQueryClient();
   const id = typeof params?.id === "string" ? params.id : "";
-  const initialTab: TabId = searchParams?.get("tab") === "topics" ? "topics" : "history";
+   const initialTab: TabId = searchParams?.get("tab") === "content" ? "topics" : "history";
 
   const [selectedMonth, setSelectedMonth] = useState(getCurrentMonthValue);
   const [activeTab, setActiveTab] = useState<TabId>(initialTab);
@@ -1158,7 +1158,7 @@ export default function StaffClassDetailPage() {
         />
 
         <ClassCard
-          title={usesTeacherScope ? "Lịch sử & Chuyên đề của bạn" : "Lịch sử & Chuyên đề"}
+           title={usesTeacherScope ? "Lịch sử & Nội dung của bạn" : "Lịch sử & Nội dung"}
           className="w-full"
         >
           <div className="mb-3 flex flex-col gap-3">
@@ -1203,7 +1203,7 @@ export default function StaffClassDetailPage() {
                 <svg className="size-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                   <path strokeLinecap="round" strokeLinejoin="round" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
                 </svg>
-                <span>Chuyên đề</span>
+                 <span>Nội dung</span>
               </button>
             </div>
 
@@ -1335,7 +1335,7 @@ export default function StaffClassDetailPage() {
               role="tabpanel"
               aria-labelledby="staff-class-detail-tab-topics"
             >
-              <StaffTopicsManager classId={id} />
+                <ClassContentManager classId={id} canManage={canManageSessions} />
             </section>
           )}
         </ClassCard>

--- a/apps/web/app/staff/classes/[id]/page.tsx
+++ b/apps/web/app/staff/classes/[id]/page.tsx
@@ -321,7 +321,7 @@ export default function StaffClassDetailPage() {
   const searchParams = useSearchParams();
   const queryClient = useQueryClient();
   const id = typeof params?.id === "string" ? params.id : "";
-   const initialTab: TabId = searchParams?.get("tab") === "content" ? "topics" : "history";
+  const initialTab: TabId = searchParams?.get("tab") === "content" ? "topics" : "history";
 
   const [selectedMonth, setSelectedMonth] = useState(getCurrentMonthValue);
   const [activeTab, setActiveTab] = useState<TabId>(initialTab);
@@ -1158,7 +1158,7 @@ export default function StaffClassDetailPage() {
         />
 
         <ClassCard
-           title={usesTeacherScope ? "Lịch sử & Nội dung của bạn" : "Lịch sử & Nội dung"}
+          title={usesTeacherScope ? "Lịch sử & Nội dung của bạn" : "Lịch sử & Nội dung"}
           className="w-full"
         >
           <div className="mb-3 flex flex-col gap-3">
@@ -1203,7 +1203,7 @@ export default function StaffClassDetailPage() {
                 <svg className="size-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                   <path strokeLinecap="round" strokeLinejoin="round" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
                 </svg>
-                 <span>Nội dung</span>
+                <span>Nội dung</span>
               </button>
             </div>
 

--- a/apps/web/app/student/classes/[id]/page.tsx
+++ b/apps/web/app/student/classes/[id]/page.tsx
@@ -123,7 +123,7 @@ export default function StudentClassDetailPage() {
           )}
         >
           <BookOpen className="size-4 sm:size-5" />
-          <span>Chuyên đề</span>
+           <span>Nội dung</span>
           {allTopics.length > 0 && (
             <span
               className={cn(

--- a/apps/web/app/student/classes/[id]/page.tsx
+++ b/apps/web/app/student/classes/[id]/page.tsx
@@ -1,15 +1,16 @@
 "use client";
 
-import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { ChevronLeft, History, BookOpen } from "lucide-react";
-import { getMyClassDetail, getMyClassSessions, getMyClassSurveys, getMyClassTopics } from "@/lib/apis/student-class.api";
+import { getMyClassDetail, getMyClassSessions, getMyClassSurveys } from "@/lib/apis/student-class.api";
+import { getStudentClassContent } from "@/lib/apis/class.api";
 import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
 import StudentSessionSurveyList from "@/components/student/StudentSessionSurveyList";
-import StudentTopicsList from "@/components/student/StudentTopicsList";
+import StudentClassContentList from "@/components/student/StudentClassContentList";
 
 type TabId = "history" | "topics";
 
@@ -44,23 +45,10 @@ export default function StudentClassDetailPage() {
     queryFn: () => getMyClassSurveys(classId),
   });
 
-  const {
-    data: topicsData,
-    isLoading: topicsLoading,
-    fetchNextPage: fetchNextTopics,
-    hasNextPage: hasNextTopics,
-    isFetchingNextPage: isFetchingNextTopics,
-  } = useInfiniteQuery({
-    queryKey: ["student-class-topics", classId],
-    queryFn: ({ pageParam = 1 }) => getMyClassTopics(classId, pageParam),
-    getNextPageParam: (lastPage) => {
-      const totalPages = Math.ceil(lastPage.total / lastPage.limit);
-      return lastPage.page < totalPages ? lastPage.page + 1 : undefined;
-    },
-    initialPageParam: 1,
+  const { data: contentItems, isLoading: contentLoading } = useQuery({
+    queryKey: ["student-class-content", classId],
+    queryFn: () => getStudentClassContent(classId),
   });
-
-  const allTopics = topicsData?.pages.flatMap((p) => p.data) ?? [];
 
   return (
     <div className="space-y-6">
@@ -123,8 +111,8 @@ export default function StudentClassDetailPage() {
           )}
         >
           <BookOpen className="size-4 sm:size-5" />
-           <span>Nội dung</span>
-          {allTopics.length > 0 && (
+          <span>Nội dung</span>
+          {(contentItems?.length ?? 0) > 0 && (
             <span
               className={cn(
                 "inline-flex items-center justify-center rounded-full px-2 py-0.5 text-xs font-bold transition-colors",
@@ -133,7 +121,7 @@ export default function StudentClassDetailPage() {
                   : "bg-bg-tertiary text-text-secondary",
               )}
             >
-              {allTopics.length}
+              {contentItems?.length}
             </span>
           )}
         </button>
@@ -150,13 +138,10 @@ export default function StudentClassDetailPage() {
             />
           )}
           {activeTab === "topics" && (
-            <StudentTopicsList
-              topics={allTopics}
+            <StudentClassContentList
+              items={contentItems ?? []}
               classId={classId}
-              isLoading={topicsLoading}
-              hasNextPage={hasNextTopics}
-              isFetchingNextPage={isFetchingNextTopics}
-              fetchNextPage={fetchNextTopics}
+              isLoading={contentLoading}
             />
           )}
         </CardContent>

--- a/apps/web/components/admin/ClassContentManager.tsx
+++ b/apps/web/components/admin/ClassContentManager.tsx
@@ -20,9 +20,13 @@ import {
 import { CSS } from "@dnd-kit/utilities";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { GripVertical, Trash2 } from "lucide-react";
+import { GripVertical, Plus, Trash2, X } from "lucide-react";
 import { Card } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
+import {
+  ResponsiveDialog,
+  ResponsiveDialogBody,
+} from "@/components/ui/ResponsiveDialog";
 import type { ClassContentItemDto } from "@/dtos/class-content.dto";
 import * as classApi from "@/lib/apis/class.api";
 
@@ -79,10 +83,14 @@ function SortableContentRow({
                 {item.kindLabel}
               </span>
               {item.chapterTitle && (
-                <span className="text-xs text-text-muted">{item.chapterTitle}</span>
+                <span className="text-xs text-text-muted">
+                  {item.chapterTitle}
+                </span>
               )}
               {item.lectureCount != null && item.lectureCount > 0 && (
-                <span className="text-xs text-text-muted">{item.lectureCount} bài học</span>
+                <span className="text-xs text-text-muted">
+                  {item.lectureCount} bài học
+                </span>
               )}
             </div>
           </div>
@@ -111,10 +119,11 @@ export default function ClassContentManager({
   const queryClient = useQueryClient();
   const [localItems, setLocalItems] = useState<ClassContentItemDto[]>([]);
   const [hasOrderChanged, setHasOrderChanged] = useState(false);
+  const [addOpen, setAddOpen] = useState(false);
 
   const { data: serverData, isLoading } = useQuery<ClassContentItemDto[]>({
     queryKey: ["class-content", classId],
-    queryFn: () => classApi.getClassContent(classId) as Promise<ClassContentItemDto[]>,
+    queryFn: () => classApi.getClassContent(classId),
   });
 
   const allItems = useMemo(
@@ -123,7 +132,8 @@ export default function ClassContentManager({
   );
 
   const reorderMutation = useMutation({
-    mutationFn: (orderedIds: string[]) => classApi.reorderClassContent(classId, orderedIds),
+    mutationFn: (orderedIds: string[]) =>
+      classApi.reorderClassContent(classId, orderedIds),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["class-content", classId] });
       setLocalItems([]);
@@ -139,7 +149,8 @@ export default function ClassContentManager({
   });
 
   const deleteMutation = useMutation({
-    mutationFn: (itemId: string) => classApi.deleteClassContentItem(classId, itemId),
+    mutationFn: (itemId: string) =>
+      classApi.deleteClassContentItem(classId, itemId),
     onSuccess: (newData) => {
       queryClient.setQueryData(["class-content", classId], newData);
       setLocalItems([]);
@@ -153,7 +164,9 @@ export default function ClassContentManager({
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
-    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
   );
 
   const handleDragEnd = useCallback(
@@ -203,21 +216,34 @@ export default function ClassContentManager({
 
   return (
     <>
-      {canManage && hasOrderChanged && (
-        <div className="flex gap-2 mb-4">
+      {canManage && (
+        <div className="flex items-center justify-between mb-4">
+          {hasOrderChanged ? (
+            <div className="flex gap-2">
+              <button
+                onClick={handleCancelOrder}
+                disabled={reorderMutation.isPending}
+                className="cursor-pointer rounded-xl border border-border-default px-4 py-2.5 text-sm font-medium text-text-secondary hover:bg-bg-secondary disabled:opacity-50"
+              >
+                Hủy
+              </button>
+              <button
+                onClick={handleSaveOrder}
+                disabled={reorderMutation.isPending}
+                className="cursor-pointer rounded-xl bg-primary px-4 py-2.5 text-sm font-medium text-text-inverse transition-colors hover:bg-primary-hover disabled:opacity-50"
+              >
+                {reorderMutation.isPending ? "Đang lưu..." : "Lưu thứ tự"}
+              </button>
+            </div>
+          ) : (
+            <div />
+          )}
           <button
-            onClick={handleCancelOrder}
-            disabled={reorderMutation.isPending}
-            className="cursor-pointer rounded-xl border border-border-default px-4 py-2.5 text-sm font-medium text-text-secondary hover:bg-bg-secondary disabled:opacity-50"
+            onClick={() => setAddOpen(true)}
+            className="inline-flex cursor-pointer items-center gap-2 rounded-xl bg-primary px-4 py-2.5 text-sm font-semibold text-text-inverse shadow-xs transition-colors hover:bg-primary-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-border-focus"
           >
-            Hủy
-          </button>
-          <button
-            onClick={handleSaveOrder}
-            disabled={reorderMutation.isPending}
-            className="cursor-pointer rounded-xl bg-primary px-4 py-2.5 text-sm font-medium text-text-inverse transition-colors hover:bg-primary-hover disabled:opacity-50"
-          >
-            {reorderMutation.isPending ? "Đang lưu..." : "Lưu thứ tự"}
+            <Plus className="size-4" />
+            Thêm nội dung
           </button>
         </div>
       )}
@@ -249,6 +275,185 @@ export default function ClassContentManager({
           </DndContext>
         )}
       </div>
+
+      {addOpen && (
+        <AddContentDialog
+          classId={classId}
+          onClose={() => setAddOpen(false)}
+          onSuccess={() => {
+            setAddOpen(false);
+            queryClient.invalidateQueries({
+              queryKey: ["class-content", classId],
+            });
+          }}
+        />
+      )}
     </>
+  );
+}
+
+function AddContentDialog({
+  classId,
+  onClose,
+  onSuccess,
+}: {
+  classId: string;
+  onClose: () => void;
+  onSuccess: () => void;
+}) {
+  const [mode, setMode] = useState<"new" | "existing">("new");
+  const [title, setTitle] = useState("");
+  const [topicId, setTopicId] = useState("");
+  const [kind, setKind] = useState<"theory" | "practice">("theory");
+
+  const createMutation = useMutation({
+    mutationFn: () =>
+      classApi.createClassContent(classId, {
+        ...(mode === "existing" ? { topicId: topicId.trim() } : {}),
+        ...(mode === "new" ? { title: title.trim(), kind } : {}),
+      }),
+    onSuccess: () => {
+      toast.success("Đã thêm nội dung");
+      onSuccess();
+    },
+    onError: (err: { response?: { data?: { message?: string } } }) => {
+      toast.error(err?.response?.data?.message || "Lỗi thêm nội dung");
+    },
+  });
+
+  const canSubmit =
+    (mode === "existing" && topicId.trim()) ||
+    (mode === "new" && title.trim());
+
+  return (
+    <ResponsiveDialog onBackdropClick={onClose} size="4xl">
+      <ResponsiveDialogBody className="flex flex-col p-4 sm:p-6 max-h-[92vh] overflow-hidden">
+        <div className="flex items-center justify-between gap-3 border-b border-border-default pb-4 shrink-0">
+          <div>
+            <h2 className="text-lg sm:text-xl font-bold text-text-primary">
+              Thêm nội dung vào lớp
+            </h2>
+            <p className="text-xs text-text-muted mt-0.5">
+              Chọn chuyên đề có sẵn từ khoá hoặc tạo mới cho lớp.
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            className="cursor-pointer rounded-lg p-1.5 text-text-muted hover:bg-bg-secondary hover:text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-border-focus"
+            aria-label="Đóng"
+          >
+            <X className="size-5" />
+          </button>
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain py-4 pr-1 [scrollbar-width:thin] space-y-4">
+          {/* Mode toggle */}
+          <div className="inline-flex items-center gap-1 rounded-xl border border-border-default bg-bg-surface p-1 shadow-2xs">
+            <button
+              type="button"
+              onClick={() => setMode("new")}
+              className={`inline-flex cursor-pointer items-center gap-1.5 rounded-lg px-3 py-1 text-xs font-semibold transition-all ${
+                mode === "new"
+                  ? "bg-primary text-text-inverse shadow-xs"
+                  : "text-text-muted hover:text-text-primary"
+              }`}
+            >
+              Tạo mới cho lớp
+            </button>
+            <button
+              type="button"
+              onClick={() => setMode("existing")}
+              className={`inline-flex cursor-pointer items-center gap-1.5 rounded-lg px-3 py-1 text-xs font-semibold transition-all ${
+                mode === "existing"
+                  ? "bg-primary text-text-inverse shadow-xs"
+                  : "text-text-muted hover:text-text-primary"
+              }`}
+            >
+              Thêm từ khoá
+            </button>
+          </div>
+
+          {mode === "new" ? (
+            <>
+              <div>
+                <label className="text-xs font-semibold uppercase tracking-wider text-text-muted">
+                  Tiêu đề <span className="text-error">*</span>
+                </label>
+                <input
+                  type="text"
+                  value={title}
+                  onChange={(e) => setTitle(e.target.value)}
+                  className="mt-1.5 w-full rounded-xl border border-border-default bg-bg-surface px-4 py-2.5 text-sm text-text-primary focus:border-border-focus focus:outline-none focus-visible:ring-2 focus-visible:ring-border-focus font-medium"
+                  placeholder="Ví dụ: Chuyên đề bổ trợ Phương trình bậc 2..."
+                />
+              </div>
+              <div>
+                <label className="text-xs font-semibold uppercase tracking-wider text-text-muted">
+                  Loại chuyên đề
+                </label>
+                <div className="mt-1.5 inline-flex items-center gap-1 rounded-xl border border-border-default bg-bg-surface p-1 shadow-2xs">
+                  <button
+                    type="button"
+                    onClick={() => setKind("theory")}
+                    className={`inline-flex cursor-pointer items-center rounded-lg px-3 py-1 text-xs font-semibold transition-all ${
+                      kind === "theory"
+                        ? "bg-primary text-text-inverse shadow-xs"
+                        : "text-text-muted hover:text-text-primary"
+                    }`}
+                  >
+                    Lý thuyết
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setKind("practice")}
+                    className={`inline-flex cursor-pointer items-center rounded-lg px-3 py-1 text-xs font-semibold transition-all ${
+                      kind === "practice"
+                        ? "bg-primary text-text-inverse shadow-xs"
+                        : "text-text-muted hover:text-text-primary"
+                    }`}
+                  >
+                    Luyện tập
+                  </button>
+                </div>
+              </div>
+            </>
+          ) : (
+            <div>
+              <label className="text-xs font-semibold uppercase tracking-wider text-text-muted">
+                ID Chuyên đề <span className="text-error">*</span>
+              </label>
+              <p className="text-xs text-text-muted mt-0.5">
+                Dán ID chuyên đề có sẵn từ khoá học để thêm vào lớp.
+              </p>
+              <input
+                type="text"
+                value={topicId}
+                onChange={(e) => setTopicId(e.target.value)}
+                className="mt-1.5 w-full rounded-xl border border-border-default bg-bg-surface px-4 py-2.5 text-sm text-text-primary focus:border-border-focus focus:outline-none focus-visible:ring-2 focus-visible:ring-border-focus font-medium"
+                placeholder="UUID của chuyên đề..."
+              />
+            </div>
+          )}
+        </div>
+
+        <div className="flex items-center justify-end gap-2 pt-4 border-t border-border-default shrink-0">
+          <button
+            type="button"
+            onClick={onClose}
+            className="cursor-pointer rounded-xl border border-border-default px-4 py-2.5 text-sm font-medium text-text-secondary hover:bg-bg-secondary transition-colors"
+          >
+            Hủy
+          </button>
+          <button
+            type="button"
+            onClick={() => createMutation.mutate()}
+            disabled={!canSubmit || createMutation.isPending}
+            className="cursor-pointer rounded-xl bg-primary px-5 py-2.5 text-sm font-semibold text-text-inverse transition-colors hover:bg-primary-hover disabled:cursor-not-allowed disabled:opacity-60 shadow-xs"
+          >
+            {createMutation.isPending ? "Đang thêm..." : "Thêm nội dung"}
+          </button>
+        </div>
+      </ResponsiveDialogBody>
+    </ResponsiveDialog>
   );
 }

--- a/apps/web/components/admin/ClassContentManager.tsx
+++ b/apps/web/components/admin/ClassContentManager.tsx
@@ -1,0 +1,254 @@
+"use client";
+
+import { useCallback, useMemo, useState, type CSSProperties } from "react";
+import {
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  closestCenter,
+  type DragEndEvent,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  arrayMove,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { GripVertical, Trash2 } from "lucide-react";
+import { Card } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import type { ClassContentItemDto } from "@/dtos/class-content.dto";
+import * as classApi from "@/lib/apis/class.api";
+
+function SortableContentRow({
+  item,
+  canManage,
+  onDelete,
+}: {
+  item: ClassContentItemDto;
+  canManage: boolean;
+  onDelete: (id: string) => void;
+}) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: item.id });
+
+  const style: CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+    zIndex: isDragging ? 50 : undefined,
+  };
+
+  return (
+    <div ref={setNodeRef} style={style}>
+      <Card className="transition-colors hover:border-border-focus/50">
+        <div className="flex items-center gap-3 p-3.5 sm:p-4">
+          {canManage && (
+            <button
+              type="button"
+              className="cursor-grab touch-none text-text-muted hover:text-text-primary p-1 -m-1"
+              title="Kéo thả để đổi thứ tự"
+              aria-label="Kéo thả để đổi thứ tự"
+              {...attributes}
+              {...listeners}
+            >
+              <GripVertical className="h-5 w-5" />
+            </button>
+          )}
+          <div className="flex-1 min-w-0">
+            <div className="flex flex-wrap items-center gap-2">
+              <h3 className="font-semibold text-text-primary text-sm sm:text-base truncate">
+                {item.title}
+              </h3>
+              <span className="inline-flex items-center rounded-full bg-primary/10 px-2 py-0.5 text-[11px] font-medium text-primary">
+                {item.source === "course" ? "Từ khoá" : "Riêng lớp"}
+              </span>
+              <span className="inline-flex items-center rounded-full bg-bg-secondary px-2 py-0.5 text-[11px] font-medium text-text-secondary">
+                {item.kindLabel}
+              </span>
+              {item.chapterTitle && (
+                <span className="text-xs text-text-muted">{item.chapterTitle}</span>
+              )}
+              {item.lectureCount != null && item.lectureCount > 0 && (
+                <span className="text-xs text-text-muted">{item.lectureCount} bài học</span>
+              )}
+            </div>
+          </div>
+          {canManage && (
+            <button
+              onClick={() => onDelete(item.id)}
+              className="inline-flex cursor-pointer items-center gap-1.5 rounded-lg border border-destructive/30 px-3 py-1.5 text-xs sm:text-sm font-medium text-destructive hover:bg-destructive/10 transition-colors shrink-0"
+            >
+              <Trash2 className="size-3.5" />
+              <span>Xóa</span>
+            </button>
+          )}
+        </div>
+      </Card>
+    </div>
+  );
+}
+
+export default function ClassContentManager({
+  classId,
+  canManage,
+}: {
+  classId: string;
+  canManage: boolean;
+}) {
+  const queryClient = useQueryClient();
+  const [localItems, setLocalItems] = useState<ClassContentItemDto[]>([]);
+  const [hasOrderChanged, setHasOrderChanged] = useState(false);
+
+  const { data: serverData, isLoading } = useQuery<ClassContentItemDto[]>({
+    queryKey: ["class-content", classId],
+    queryFn: () => classApi.getClassContent(classId) as Promise<ClassContentItemDto[]>,
+  });
+
+  const allItems = useMemo(
+    () => (localItems.length > 0 ? localItems : serverData ?? []),
+    [localItems, serverData],
+  );
+
+  const reorderMutation = useMutation({
+    mutationFn: (orderedIds: string[]) => classApi.reorderClassContent(classId, orderedIds),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["class-content", classId] });
+      setLocalItems([]);
+      setHasOrderChanged(false);
+      toast.success("Đã lưu thứ tự");
+    },
+    onError: () => {
+      toast.error("Lỗi sắp xếp lại nội dung lớp");
+      queryClient.invalidateQueries({ queryKey: ["class-content", classId] });
+      setLocalItems([]);
+      setHasOrderChanged(false);
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (itemId: string) => classApi.deleteClassContentItem(classId, itemId),
+    onSuccess: (newData) => {
+      queryClient.setQueryData(["class-content", classId], newData);
+      setLocalItems([]);
+      setHasOrderChanged(false);
+      toast.success("Đã xóa nội dung");
+    },
+    onError: () => {
+      toast.error("Xóa nội dung lớp thất bại");
+    },
+  });
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
+
+      const oldIndex = allItems.findIndex((t) => t.id === active.id);
+      const newIndex = allItems.findIndex((t) => t.id === over.id);
+      if (oldIndex === -1 || newIndex === -1) return;
+
+      const reordered = arrayMove(allItems, oldIndex, newIndex);
+      setLocalItems(reordered);
+      setHasOrderChanged(true);
+    },
+    [allItems],
+  );
+
+  const handleSaveOrder = useCallback(() => {
+    if (!hasOrderChanged || localItems.length === 0) return;
+    reorderMutation.mutate(localItems.map((t) => t.id));
+  }, [hasOrderChanged, localItems, reorderMutation]);
+
+  const handleCancelOrder = useCallback(() => {
+    setLocalItems([]);
+    setHasOrderChanged(false);
+  }, []);
+
+  const handleDelete = useCallback(
+    (itemId: string) => {
+      if (confirm("Bạn có chắc xóa mục này?")) {
+        deleteMutation.mutate(itemId);
+      }
+    },
+    [deleteMutation],
+  );
+
+  if (isLoading) {
+    return (
+      <div className="space-y-3">
+        {[1, 2, 3].map((i) => (
+          <Skeleton key={i} className="h-16 w-full rounded-xl" />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {canManage && hasOrderChanged && (
+        <div className="flex gap-2 mb-4">
+          <button
+            onClick={handleCancelOrder}
+            disabled={reorderMutation.isPending}
+            className="cursor-pointer rounded-xl border border-border-default px-4 py-2.5 text-sm font-medium text-text-secondary hover:bg-bg-secondary disabled:opacity-50"
+          >
+            Hủy
+          </button>
+          <button
+            onClick={handleSaveOrder}
+            disabled={reorderMutation.isPending}
+            className="cursor-pointer rounded-xl bg-primary px-4 py-2.5 text-sm font-medium text-text-inverse transition-colors hover:bg-primary-hover disabled:opacity-50"
+          >
+            {reorderMutation.isPending ? "Đang lưu..." : "Lưu thứ tự"}
+          </button>
+        </div>
+      )}
+
+      <div className="space-y-2.5">
+        {allItems.length === 0 ? (
+          <div className="rounded-2xl border border-dashed border-border-default bg-bg-secondary/20 p-8 text-center text-sm text-text-muted">
+            Chưa có nội dung nào trong lớp học này.
+          </div>
+        ) : (
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragEnd={handleDragEnd}
+          >
+            <SortableContext
+              items={allItems.map((t) => t.id)}
+              strategy={verticalListSortingStrategy}
+            >
+              {allItems.map((item) => (
+                <SortableContentRow
+                  key={item.id}
+                  item={item}
+                  canManage={canManage}
+                  onDelete={handleDelete}
+                />
+              ))}
+            </SortableContext>
+          </DndContext>
+        )}
+      </div>
+    </>
+  );
+}

--- a/apps/web/components/student/StudentClassContentList.tsx
+++ b/apps/web/components/student/StudentClassContentList.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import Link from "next/link";
+import type { ClassContentItemDto } from "@/dtos/class-content.dto";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function StudentClassContentList({
+  items,
+  classId,
+  isLoading,
+}: {
+  items: ClassContentItemDto[];
+  classId: string;
+  isLoading: boolean;
+}) {
+  if (isLoading) {
+    return (
+      <div className="space-y-3">
+        {[1, 2, 3].map((i) => (
+          <Skeleton key={i} className="h-20 w-full rounded-xl" />
+        ))}
+      </div>
+    );
+  }
+
+  if (!items.length) {
+    return (
+      <div className="rounded-xl border border-dashed border-border-default bg-bg-secondary/20 p-8 text-center text-sm text-text-muted">
+        Chưa có nội dung học tập nào trong lớp học này.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {items.map((item, index) => {
+        const topicHref = `/student/classes/${classId}/topics/${item.topicId}`;
+
+        return (
+          <Link
+            key={item.id}
+            href={topicHref}
+            className="group flex items-center justify-between gap-3 rounded-xl border border-border-default bg-bg-surface p-4 transition-all duration-200 hover:border-primary/50 hover:bg-bg-secondary/60 hover:shadow-sm"
+          >
+            <div className="flex items-center gap-3 min-w-0">
+              <div className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-xs font-bold text-primary">
+                {index + 1}
+              </div>
+              <div className="min-w-0 flex-1">
+                <div className="flex flex-wrap items-center gap-2">
+                  <h3 className="font-semibold text-text-primary group-hover:text-primary transition-colors truncate">
+                    {item.title}
+                  </h3>
+                  <span className="inline-flex items-center rounded-full bg-bg-secondary px-2 py-0.5 text-[10px] font-semibold text-text-secondary">
+                    {item.kindLabel}
+                  </span>
+                  {item.chapterTitle && (
+                    <span className="text-[10px] text-text-muted">
+                      {item.chapterTitle}
+                    </span>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            <div className="flex items-center justify-end gap-2 shrink-0">
+              <span className="text-xs font-medium text-text-muted group-hover:text-primary flex items-center gap-1">
+                Xem nội dung
+                <svg
+                  className="size-4 transition-transform group-hover:translate-x-1"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M9 5l7 7-7 7"
+                  />
+                </svg>
+              </span>
+            </div>
+          </Link>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/dtos/class-content.dto.ts
+++ b/apps/web/dtos/class-content.dto.ts
@@ -1,0 +1,11 @@
+export interface ClassContentItemDto {
+  id: string; // class_content_items.id
+  topicId: string;
+  kind: 'topic'; // future kinds will be added
+  sortOrder: number;
+  title: string;
+  kindLabel: string; // e.g., 'Lý thuyết' | 'Luyện tập'
+  source: 'course' | 'class'; // source badge
+  chapterTitle?: string; // for course topics
+  lectureCount?: number; // for theory topics
+}

--- a/apps/web/dtos/class-content.dto.ts
+++ b/apps/web/dtos/class-content.dto.ts
@@ -9,3 +9,9 @@ export interface ClassContentItemDto {
   chapterTitle?: string; // for course topics
   lectureCount?: number; // for theory topics
 }
+
+export interface ClassContentCreatePayload {
+  topicId?: string; // add existing topic
+  title?: string; // title for new topic (required when topicId is absent)
+  kind?: 'theory' | 'practice'; // default 'theory'
+}

--- a/apps/web/lib/apis/class.api.ts
+++ b/apps/web/lib/apis/class.api.ts
@@ -389,6 +389,25 @@ export async function assignCourseLessonPlanMembers(
   return response.data;
 }
 
+export async function getClassContent(classId: string): Promise<unknown[]> {
+  const safeId = encodeURIComponent(classId);
+  const response = await api.get(`/class/${safeId}/content`);
+  return response.data;
+}
+
+export async function reorderClassContent(classId: string, orderedIds: string[]): Promise<unknown[]> {
+  const safeId = encodeURIComponent(classId);
+  const response = await api.post(`/class/${safeId}/content/reorder`, { orderedIds });
+  return response.data;
+}
+
+export async function deleteClassContentItem(classId: string, itemId: string): Promise<unknown[]> {
+  const safeClassId = encodeURIComponent(classId);
+  const safeItemId = encodeURIComponent(itemId);
+  const response = await api.delete(`/class/${safeClassId}/content/${safeItemId}`);
+  return response.data;
+}
+
 export async function getClassById(id: string): Promise<ClassDetail> {
   const safeId = encodeURIComponent(id);
   const response = await api.get(`/class/${safeId}`);

--- a/apps/web/lib/apis/class.api.ts
+++ b/apps/web/lib/apis/class.api.ts
@@ -43,6 +43,7 @@ import type {
 } from "@/dtos/class-survey.dto";
 import { normalizeMakeupScheduleEvent, normalizeMakeupScheduleFeedResponse } from "./class-schedule.api";
 import { api } from "../client";
+import type { ClassContentItemDto, ClassContentCreatePayload } from "@/dtos/class-content.dto";
 
 function normalizeOperatingDeductionRatePercent(
   teacher: Record<string, unknown>,
@@ -389,22 +390,47 @@ export async function assignCourseLessonPlanMembers(
   return response.data;
 }
 
-export async function getClassContent(classId: string): Promise<unknown[]> {
+export async function getClassContent(classId: string): Promise<ClassContentItemDto[]> {
   const safeId = encodeURIComponent(classId);
-  const response = await api.get(`/class/${safeId}/content`);
+  const response = await api.get<ClassContentItemDto[]>(`/class/${safeId}/content`);
   return response.data;
 }
 
-export async function reorderClassContent(classId: string, orderedIds: string[]): Promise<unknown[]> {
+export async function createClassContent(
+  classId: string,
+  payload: ClassContentCreatePayload,
+): Promise<ClassContentItemDto> {
   const safeId = encodeURIComponent(classId);
-  const response = await api.post(`/class/${safeId}/content/reorder`, { orderedIds });
+  const response = await api.post<ClassContentItemDto>(`/class/${safeId}/content`, payload);
   return response.data;
 }
 
-export async function deleteClassContentItem(classId: string, itemId: string): Promise<unknown[]> {
+export async function reorderClassContent(
+  classId: string,
+  orderedIds: string[],
+): Promise<ClassContentItemDto[]> {
+  const safeId = encodeURIComponent(classId);
+  const response = await api.post<ClassContentItemDto[]>(`/class/${safeId}/content/reorder`, {
+    orderedIds,
+  });
+  return response.data;
+}
+
+export async function deleteClassContentItem(
+  classId: string,
+  itemId: string,
+): Promise<ClassContentItemDto[]> {
   const safeClassId = encodeURIComponent(classId);
   const safeItemId = encodeURIComponent(itemId);
-  const response = await api.delete(`/class/${safeClassId}/content/${safeItemId}`);
+  const response = await api.delete<ClassContentItemDto[]>(
+    `/class/${safeClassId}/content/${safeItemId}`,
+  );
+  return response.data;
+}
+
+export async function getStudentClassContent(classId: string): Promise<ClassContentItemDto[]> {
+  const safeId = encodeURIComponent(classId);
+  const response = await api.get<ClassContentItemDto[]>(`/class/${safeId}/content/student`);
   return response.data;
 }
 

--- a/docs/Database Schema.md
+++ b/docs/Database Schema.md
@@ -379,6 +379,16 @@ Tài liệu này được tổng hợp trực tiếp từ Prisma schema tại `a
   - composite `(class_id, status, created_at)` (hot path cho danh sách roster theo lớp/trạng thái)
   - composite `(student_id, class_id)` (hot path cho membership lookups theo học sinh)
 
+### 4.4.0b `class_content_items` (Nội dung lớp học)
+
+- Bảng liên kết lớp ↔ nội dung: mỗi hàng là một mục nội dung (hiện tại chỉ `topic`) được thêm vào danh sách nội dung của lớp.
+- `class_id` (FK → `classes.id`, `onDelete: Cascade`)
+- `kind` (`ClassContentItemKind`, default `topic`) — phân loại nội dung. Hiện tại chỉ có `topic`, mở rộng thêm kinds trong tương lai.
+- `topic_id` (nullable FK → `topics.id`, `onDelete: Cascade`) — FK đến chuyên đề. Nullable để hỗ trợ future kinds không cần topic.
+- `sort_order` (`INT`, default 0) — thứ tự hiển thị trong danh sách nội dung lớp.
+- Unique constraint: `(class_id, topic_id)` — mỗi chuyên đề chỉ xuất hiện tối đa 1 lần trong nội dung của một lớp.
+- Migration: `20260910000000_add_class_content_items` — tạo bảng + backfill các topic hiện có (`topic.class_id IS NOT NULL`) thành class_content_item.
+
 ### 4.4.1 `makeup_schedule_events`
 
 - Buổi dạy bù được tạo thủ công từ trang chi tiết lớp; mỗi record là **một buổi duy nhất**, không lặp lại.
@@ -749,6 +759,7 @@ Tài liệu này được tổng hợp trực tiếp từ Prisma schema tại `a
 - `AttendanceStatus`: `present | excused | absent`
 - `TopicKind`: `theory | practice` — phân loại chuyên đề: `theory` (lý thuyết, có thể chứa nhiều lectures) hoặc `practice` (thực hành)
 - `TopicKind`: `theory | practice`
+- `ClassContentItemKind`: `topic` — phân loại nội dung lớp học (mở rộng thêm kinds trong tương lai)
 
 ### Finance
 


### PR DESCRIPTION
## What

Thêm tab **Nội dung** vào trang chi tiết lớp học (admin/staff), cho phép gia sư quản lý danh sách nội dung lớp: xem, sắp xếp lại thứ tự (drag-and-drop), và xóa mục khỏi lớp.

## Changes

### Backend
- **Prisma schema**: Thêm  model + enum  vào 
- **Migration**:  — tạo bảng + backfill topic hiện có
- **TopicService**: Thêm 4 methods: , , , 
- **ClassContentController**: CRUD routes mới tại 

### Frontend
- **ClassContentManager**: Component mới với  drag-and-drop reorder, TanStack Query v5, Sonner toast
- **Class pages**: Tích hợp tab Nội dung vào admin/staff/student class detail pages
- **API client**: Thêm , , 

### Docs
- Cập nhật  với bảng  và enum 

## Acceptance Criteria
- [x] Tab Nội dung nằm trong trang chi tiết lớp hiện có, không tạo route mới
- [x] Liệt kê nội dung của lớp, phân biệt rõ nguồn (từ khoá / riêng lớp)
- [x] Sắp xếp lại thứ tự (drag-and-drop), gỡ khỏi lớp
- [x] Học sinh chỉ thấy đúng những mục đã thêm vào lớp
- [x] Mobile-first (responsive classes: , )
- [x] ESLint clean, Prisma validate clean, tsc clean