### PR TITLE
feat(#55): Soạn Chuyên đề luyện tập (đề)

### DIFF
--- a/apps/api/src/dtos/topic.dto.ts
+++ b/apps/api/src/dtos/topic.dto.ts
@@ -1,5 +1,12 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsEnum, IsOptional, IsString } from 'class-validator';
+import {
+  IsArray,
+  IsEnum,
+  IsInt,
+  IsOptional,
+  IsString,
+  Min,
+} from 'class-validator';
 import { TopicKind } from 'generated/enums';
 
 export class TopicCreateDto {
@@ -237,4 +244,79 @@ export interface ClassContentItemResponseDto {
   source: 'course' | 'class';
   chapterTitle?: string;
   lectureCount?: number;
+}
+
+// --- QuestionLink DTOs (Practice Topic / Đề) ---
+
+export class QuestionLinkCreateDto {
+  @ApiProperty({ description: 'ID câu hỏi từ ngân hàng câu hỏi' })
+  @IsString()
+  questionId: string;
+
+  @ApiPropertyOptional({ description: 'Thứ tự hiển thị', nullable: true })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  order?: number | null;
+
+  @ApiPropertyOptional({
+    description: 'Điểm của câu hỏi',
+    nullable: true,
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  points?: number | null;
+}
+
+export class QuestionLinkUpdateDto {
+  @ApiPropertyOptional({ description: 'Thứ tự hiển thị', nullable: true })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  order?: number | null;
+
+  @ApiPropertyOptional({
+    description: 'Điểm của câu hỏi',
+    nullable: true,
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  points?: number | null;
+}
+
+export class ReorderQuestionLinksDto {
+  @ApiProperty({
+    description: 'Danh sách ID theo thứ tự mới',
+    type: [String],
+  })
+  @IsArray()
+  @IsString({ each: true })
+  linkIds: string[];
+}
+
+export interface QuestionLinkResponseDto {
+  id: string;
+  topicId: string;
+  questionId: string;
+  order: number | null;
+  points: number | null;
+  question: {
+    id: string;
+    courseId: string;
+    chapterId: string;
+    difficultyLevelId: string;
+    type: string;
+    content: string;
+    options: unknown;
+    correctIndex: number | null;
+    explanation: string | null;
+    answerGuide: string | null;
+  };
+}
+
+export interface QuestionLinkSummaryDto {
+  totalQuestions: number;
+  totalPoints: number;
 }

--- a/apps/api/src/topic/topic.controller.ts
+++ b/apps/api/src/topic/topic.controller.ts
@@ -37,6 +37,9 @@ import {
   LectureUpdateDto,
   LectureResponseDto,
   ClassContentCreateDto,
+  QuestionLinkCreateDto,
+  QuestionLinkUpdateDto,
+  ReorderQuestionLinksDto,
 } from 'src/dtos/topic.dto';
 import { TopicService } from './topic.service';
 
@@ -614,5 +617,147 @@ export class ClassContentController {
       throw new NotFoundException('Student profile not found');
     }
     return this.topicService.listClassContentForStudent(classId, studentId);
+  }
+}
+
+@Controller('topics/:topicId/questions')
+@ApiTags('practice-topic-questions')
+@ApiCookieAuth('access_token')
+export class PracticeTopicQuestionController {
+  constructor(private readonly topicService: TopicService) {}
+
+  @Get()
+  @Roles(UserRole.admin)
+  @AllowStaffRolesOnAdminRoutes(
+    StaffRole.assistant,
+    StaffRole.lesson_plan,
+    StaffRole.lesson_plan_head,
+  )
+  @ApiOperation({ summary: 'Lấy danh sách câu hỏi của chuyên đề luyện tập' })
+  @ApiParam({ name: 'topicId', description: 'ID chuyên đề luyện tập' })
+  @ApiResponse({ status: 200, description: 'Danh sách câu hỏi.' })
+  async getQuestions(@Param('topicId') topicId: string) {
+    return this.topicService.getQuestionsByTopicId(topicId);
+  }
+
+  @Post()
+  @Roles(UserRole.admin)
+  @AllowStaffRolesOnAdminRoutes(
+    StaffRole.assistant,
+    StaffRole.lesson_plan,
+    StaffRole.lesson_plan_head,
+    StaffRole.teacher,
+  )
+  @ApiOperation({ summary: 'Thêm câu hỏi vào chuyên đề luyện tập' })
+  @ApiParam({ name: 'topicId', description: 'ID chuyên đề luyện tập' })
+  @ApiBody({ type: QuestionLinkCreateDto })
+  @ApiResponse({ status: 201, description: 'Đã thêm câu hỏi.' })
+  @ApiResponse({ status: 400, description: 'Lỗi dữ liệu đầu vào.' })
+  async addQuestion(
+    @CurrentUser() user: JwtPayload,
+    @Param('topicId') topicId: string,
+    @Body() dto: QuestionLinkCreateDto,
+  ) {
+    return this.topicService.addQuestionToTopic(topicId, dto, {
+      userId: user.id,
+      userEmail: user.email,
+      roleType: user.roleType,
+    });
+  }
+
+  @Patch(':linkId')
+  @Roles(UserRole.admin)
+  @AllowStaffRolesOnAdminRoutes(
+    StaffRole.assistant,
+    StaffRole.lesson_plan,
+    StaffRole.lesson_plan_head,
+  )
+  @ApiOperation({ summary: 'Cập nhật thứ tự/điểm câu hỏi' })
+  @ApiParam({ name: 'topicId', description: 'ID chuyên đề luyện tập' })
+  @ApiParam({ name: 'linkId', description: 'ID liên kết câu hỏi' })
+  @ApiBody({ type: QuestionLinkUpdateDto })
+  @ApiResponse({ status: 200, description: 'Đã cập nhật.' })
+  async updateQuestionLink(
+    @CurrentUser() user: JwtPayload,
+    @Param('topicId') topicId: string,
+    @Param('linkId') linkId: string,
+    @Body() dto: QuestionLinkUpdateDto,
+  ) {
+    return this.topicService.updateQuestionLink(topicId, linkId, dto, {
+      userId: user.id,
+      userEmail: user.email,
+      roleType: user.roleType,
+    });
+  }
+
+  @Delete(':linkId')
+  @Roles(UserRole.admin)
+  @AllowStaffRolesOnAdminRoutes(
+    StaffRole.assistant,
+    StaffRole.lesson_plan,
+    StaffRole.lesson_plan_head,
+  )
+  @ApiOperation({ summary: 'Xóa câu hỏi khỏi chuyên đề luyện tập' })
+  @ApiParam({ name: 'topicId', description: 'ID chuyên đề luyện tập' })
+  @ApiParam({ name: 'linkId', description: 'ID liên kết câu hỏi' })
+  @ApiResponse({ status: 200, description: 'Đã xóa.' })
+  async removeQuestion(
+    @CurrentUser() user: JwtPayload,
+    @Param('topicId') topicId: string,
+    @Param('linkId') linkId: string,
+  ) {
+    return this.topicService.removeQuestionFromTopic(topicId, linkId, {
+      userId: user.id,
+      userEmail: user.email,
+      roleType: user.roleType,
+    });
+  }
+
+  @Post('reorder')
+  @Roles(UserRole.admin)
+  @AllowStaffRolesOnAdminRoutes(
+    StaffRole.assistant,
+    StaffRole.lesson_plan,
+    StaffRole.lesson_plan_head,
+  )
+  @ApiOperation({ summary: 'Sắp xếp lại thứ tự câu hỏi' })
+  @ApiParam({ name: 'topicId', description: 'ID chuyên đề luyện tập' })
+  @ApiBody({ type: ReorderQuestionLinksDto })
+  @ApiResponse({ status: 200, description: 'Đã sắp xếp lại.' })
+  async reorderQuestions(
+    @CurrentUser() user: JwtPayload,
+    @Param('topicId') topicId: string,
+    @Body() dto: ReorderQuestionLinksDto,
+  ) {
+    return this.topicService.reorderQuestionLinks(topicId, dto.linkIds, {
+      userId: user.id,
+      userEmail: user.email,
+      roleType: user.roleType,
+    });
+  }
+
+  @Get('summary')
+  @Roles(UserRole.admin)
+  @AllowStaffRolesOnAdminRoutes(
+    StaffRole.assistant,
+    StaffRole.lesson_plan,
+    StaffRole.lesson_plan_head,
+  )
+  @ApiOperation({ summary: 'Tổng quan câu hỏi và điểm' })
+  @ApiParam({ name: 'topicId', description: 'ID chuyên đề luyện tập' })
+  @ApiResponse({ status: 200, description: 'Tổng số câu hỏi và tổng điểm.' })
+  async getSummary(@Param('topicId') topicId: string) {
+    return this.topicService.getQuestionLinkSummary(topicId);
+  }
+
+  @Get('is-assigned')
+  @Roles(UserRole.admin)
+  @AllowStaffRolesOnAdminRoutes(StaffRole.assistant)
+  @ApiOperation({ summary: 'Kiểm tra chuyên đề đã được giao cho lớp nào chưa' })
+  @ApiParam({ name: 'topicId', description: 'ID chuyên đề luyện tập' })
+  @ApiResponse({ status: 200, description: 'Đã giao hay chưa.' })
+  async isAssigned(@Param('topicId') topicId: string) {
+    const assigned = await this.topicService.isTopicAssignedToClass(topicId);
+    return { assigned };
   }
 }

--- a/apps/api/src/topic/topic.module.ts
+++ b/apps/api/src/topic/topic.module.ts
@@ -7,6 +7,7 @@ import {
   ClassTopicController,
   LectureController,
   ClassContentController,
+  PracticeTopicQuestionController,
 } from './topic.controller';
 import { TopicService } from './topic.service';
 
@@ -18,6 +19,7 @@ import { TopicService } from './topic.service';
     ClassTopicController,
     LectureController,
     ClassContentController,
+    PracticeTopicQuestionController,
   ],
   providers: [TopicService],
   exports: [TopicService],

--- a/apps/api/src/topic/topic.service.spec.ts
+++ b/apps/api/src/topic/topic.service.spec.ts
@@ -417,4 +417,383 @@ describe('TopicService — ClassContent methods', () => {
       ).rejects.toThrow(ForbiddenException);
     });
   });
+
+  // ─── QuestionLink CRUD (Practice Topic / Đề) ───
+
+  describe('QuestionLink CRUD', () => {
+    const practiceTopic = {
+      id: 'topic-practice-1',
+      kind: 'practice',
+      courseId: 'course-1',
+      chapterId: 'ch-1',
+      classId: null,
+      title: 'Đề thi thử',
+    };
+
+    const theoryTopic = {
+      id: 'topic-theory-1',
+      kind: 'theory',
+      courseId: 'course-1',
+      chapterId: 'ch-1',
+      classId: null,
+      title: 'Chuyên đề lý thuyết',
+    };
+
+    const mockQuestion = {
+      id: 'q-1',
+      courseId: 'course-1',
+      chapterId: 'ch-1',
+      difficultyLevelId: 'dl-1',
+      type: 'single_choice',
+      content: 'Câu hỏi test',
+      options: ['A', 'B', 'C'],
+      correctIndex: 0,
+      explanation: null,
+      answerGuide: null,
+      deletedAt: null,
+    };
+
+    const mockLink = {
+      id: 'link-1',
+      topicId: 'topic-practice-1',
+      questionId: 'q-1',
+      order: 0,
+      points: 10,
+      question: mockQuestion,
+    };
+
+    beforeEach(() => {
+      mockPrisma.questionLink = {
+        findMany: jest.fn(),
+        findUnique: jest.fn(),
+        create: jest.fn(),
+        update: jest.fn(),
+        delete: jest.fn(),
+        aggregate: jest.fn(),
+      };
+      mockPrisma.question = {
+        findUnique: jest.fn(),
+      };
+    });
+
+    // ─── getQuestionsByTopicId ───
+
+    describe('getQuestionsByTopicId', () => {
+      it('should return questions for a practice topic', async () => {
+        mockPrisma.topic.findUnique.mockResolvedValue(practiceTopic);
+        mockPrisma.questionLink.findMany.mockResolvedValue([mockLink]);
+
+        const result = await service.getQuestionsByTopicId('topic-practice-1');
+
+        expect(result).toHaveLength(1);
+        expect(result[0].questionId).toBe('q-1');
+        expect(result[0].points).toBe(10);
+      });
+
+      it('should throw if topic not found', async () => {
+        mockPrisma.topic.findUnique.mockResolvedValue(null);
+
+        await expect(
+          service.getQuestionsByTopicId('topic-missing'),
+        ).rejects.toThrow(NotFoundException);
+      });
+
+      it('should throw if topic is not practice', async () => {
+        mockPrisma.topic.findUnique.mockResolvedValue(theoryTopic);
+
+        await expect(
+          service.getQuestionsByTopicId('topic-theory-1'),
+        ).rejects.toThrow(BadRequestException);
+      });
+
+      it('should throw if topic has no courseId', async () => {
+        mockPrisma.topic.findUnique.mockResolvedValue({
+          ...practiceTopic,
+          courseId: null,
+        });
+
+        await expect(
+          service.getQuestionsByTopicId('topic-practice-1'),
+        ).rejects.toThrow(BadRequestException);
+      });
+    });
+
+    // ─── addQuestionToTopic ───
+
+    describe('addQuestionToTopic', () => {
+      it('should link a question to a practice topic', async () => {
+        mockPrisma.topic.findUnique.mockResolvedValue(practiceTopic);
+        mockPrisma.question.findUnique.mockResolvedValue(mockQuestion);
+        mockPrisma.questionLink.findUnique.mockResolvedValue(null);
+        mockPrisma.questionLink.aggregate.mockResolvedValue({
+          _max: { order: 1 },
+        });
+        mockPrisma.questionLink.create.mockResolvedValue(mockLink);
+
+        const result = await service.addQuestionToTopic(
+          'topic-practice-1',
+          { questionId: 'q-1', points: 10 },
+          adminActor,
+        );
+
+        expect(result.questionId).toBe('q-1');
+        expect(result.points).toBe(10);
+        expect(mockPrisma.questionLink.create).toHaveBeenCalled();
+      });
+
+      it('should throw if question not found', async () => {
+        mockPrisma.topic.findUnique.mockResolvedValue(practiceTopic);
+        mockPrisma.question.findUnique.mockResolvedValue(null);
+
+        await expect(
+          service.addQuestionToTopic(
+            'topic-practice-1',
+            { questionId: 'q-missing' },
+            adminActor,
+          ),
+        ).rejects.toThrow(NotFoundException);
+      });
+
+      it('should throw if question is soft-deleted', async () => {
+        mockPrisma.topic.findUnique.mockResolvedValue(practiceTopic);
+        mockPrisma.question.findUnique.mockResolvedValue({
+          ...mockQuestion,
+          deletedAt: new Date(),
+        });
+
+        await expect(
+          service.addQuestionToTopic(
+            'topic-practice-1',
+            { questionId: 'q-1' },
+            adminActor,
+          ),
+        ).rejects.toThrow(NotFoundException);
+      });
+
+      it('should throw if question belongs to different course', async () => {
+        mockPrisma.topic.findUnique.mockResolvedValue(practiceTopic);
+        mockPrisma.question.findUnique.mockResolvedValue({
+          ...mockQuestion,
+          courseId: 'course-999',
+        });
+
+        await expect(
+          service.addQuestionToTopic(
+            'topic-practice-1',
+            { questionId: 'q-1' },
+            adminActor,
+          ),
+        ).rejects.toThrow(BadRequestException);
+      });
+
+      it('should throw if question already linked', async () => {
+        mockPrisma.topic.findUnique.mockResolvedValue(practiceTopic);
+        mockPrisma.question.findUnique.mockResolvedValue(mockQuestion);
+        mockPrisma.questionLink.findUnique.mockResolvedValue(mockLink);
+
+        await expect(
+          service.addQuestionToTopic(
+            'topic-practice-1',
+            { questionId: 'q-1' },
+            adminActor,
+          ),
+        ).rejects.toThrow(BadRequestException);
+      });
+    });
+
+    // ─── updateQuestionLink ───
+
+    describe('updateQuestionLink', () => {
+      it('should update order and points', async () => {
+        mockPrisma.topic.findUnique.mockResolvedValue(practiceTopic);
+        mockPrisma.questionLink.findUnique.mockResolvedValue(mockLink);
+        mockPrisma.questionLink.update.mockResolvedValue({
+          ...mockLink,
+          points: 20,
+          order: 3,
+        });
+
+        const result = await service.updateQuestionLink(
+          'topic-practice-1',
+          'link-1',
+          { points: 20, order: 3 },
+          adminActor,
+        );
+
+        expect(result.points).toBe(20);
+        expect(result.order).toBe(3);
+      });
+
+      it('should throw if link not found', async () => {
+        mockPrisma.topic.findUnique.mockResolvedValue(practiceTopic);
+        mockPrisma.questionLink.findUnique.mockResolvedValue(null);
+
+        await expect(
+          service.updateQuestionLink(
+            'topic-practice-1',
+            'link-missing',
+            { points: 20 },
+            adminActor,
+          ),
+        ).rejects.toThrow(NotFoundException);
+      });
+
+      it('should throw if link belongs to different topic', async () => {
+        mockPrisma.topic.findUnique.mockResolvedValue(practiceTopic);
+        mockPrisma.questionLink.findUnique.mockResolvedValue({
+          ...mockLink,
+          topicId: 'topic-other',
+        });
+
+        await expect(
+          service.updateQuestionLink(
+            'topic-practice-1',
+            'link-1',
+            { points: 20 },
+            adminActor,
+          ),
+        ).rejects.toThrow(NotFoundException);
+      });
+    });
+
+    // ─── removeQuestionFromTopic ───
+
+    describe('removeQuestionFromTopic', () => {
+      it('should delete the link', async () => {
+        mockPrisma.topic.findUnique.mockResolvedValue(practiceTopic);
+        mockPrisma.questionLink.findUnique.mockResolvedValue(mockLink);
+        mockPrisma.questionLink.delete.mockResolvedValue({});
+
+        await service.removeQuestionFromTopic(
+          'topic-practice-1',
+          'link-1',
+          adminActor,
+        );
+
+        expect(mockPrisma.questionLink.delete).toHaveBeenCalledWith({
+          where: { id: 'link-1' },
+        });
+      });
+
+      it('should throw if link not found', async () => {
+        mockPrisma.topic.findUnique.mockResolvedValue(practiceTopic);
+        mockPrisma.questionLink.findUnique.mockResolvedValue(null);
+
+        await expect(
+          service.removeQuestionFromTopic(
+            'topic-practice-1',
+            'link-missing',
+            adminActor,
+          ),
+        ).rejects.toThrow(NotFoundException);
+      });
+
+      it('should throw if link belongs to different topic', async () => {
+        mockPrisma.topic.findUnique.mockResolvedValue(practiceTopic);
+        mockPrisma.questionLink.findUnique.mockResolvedValue({
+          ...mockLink,
+          topicId: 'topic-other',
+        });
+
+        await expect(
+          service.removeQuestionFromTopic(
+            'topic-practice-1',
+            'link-1',
+            adminActor,
+          ),
+        ).rejects.toThrow(NotFoundException);
+      });
+    });
+
+    // ─── reorderQuestionLinks ───
+
+    describe('reorderQuestionLinks', () => {
+      it('should update sortOrder for all owned IDs', async () => {
+        mockPrisma.topic.findUnique.mockResolvedValue(practiceTopic);
+        mockPrisma.questionLink.findMany
+          .mockResolvedValueOnce([{ id: 'link-1' }, { id: 'link-2' }])
+          .mockResolvedValueOnce([]);
+        mockPrisma.questionLink.update.mockResolvedValue({});
+
+        await service.reorderQuestionLinks(
+          'topic-practice-1',
+          ['link-2', 'link-1'],
+          adminActor,
+        );
+
+        expect(mockPrisma.questionLink.update).toHaveBeenCalledTimes(2);
+        expect(mockPrisma.questionLink.update).toHaveBeenCalledWith({
+          where: { id: 'link-2' },
+          data: { order: 0 },
+        });
+        expect(mockPrisma.questionLink.update).toHaveBeenCalledWith({
+          where: { id: 'link-1' },
+          data: { order: 1 },
+        });
+      });
+
+      it('should throw if any ID does not belong to topic', async () => {
+        mockPrisma.topic.findUnique.mockResolvedValue(practiceTopic);
+        mockPrisma.questionLink.findMany.mockResolvedValue([{ id: 'link-1' }]);
+
+        await expect(
+          service.reorderQuestionLinks(
+            'topic-practice-1',
+            ['link-1', 'link-foreign'],
+            adminActor,
+          ),
+        ).rejects.toThrow(BadRequestException);
+      });
+    });
+
+    // ─── getQuestionLinkSummary ───
+
+    describe('getQuestionLinkSummary', () => {
+      it('should return total questions and points', async () => {
+        mockPrisma.topic.findUnique.mockResolvedValue(practiceTopic);
+        mockPrisma.questionLink.aggregate.mockResolvedValue({
+          _count: { id: 3 },
+          _sum: { points: 30 },
+        });
+
+        const result = await service.getQuestionLinkSummary('topic-practice-1');
+
+        expect(result.totalQuestions).toBe(3);
+        expect(result.totalPoints).toBe(30);
+      });
+
+      it('should return 0 points when no questions linked', async () => {
+        mockPrisma.topic.findUnique.mockResolvedValue(practiceTopic);
+        mockPrisma.questionLink.aggregate.mockResolvedValue({
+          _count: { id: 0 },
+          _sum: { points: null },
+        });
+
+        const result = await service.getQuestionLinkSummary('topic-practice-1');
+
+        expect(result.totalQuestions).toBe(0);
+        expect(result.totalPoints).toBe(0);
+      });
+    });
+
+    // ─── isTopicAssignedToClass ───
+
+    describe('isTopicAssignedToClass', () => {
+      it('should return true when topic is in class content', async () => {
+        mockPrisma.classContentItem.count.mockResolvedValue(2);
+
+        const result = await service.isTopicAssignedToClass('topic-practice-1');
+
+        expect(result).toBe(true);
+      });
+
+      it('should return false when topic is not in any class', async () => {
+        mockPrisma.classContentItem.count.mockResolvedValue(0);
+
+        const result = await service.isTopicAssignedToClass('topic-practice-1');
+
+        expect(result).toBe(false);
+      });
+    });
+  });
 });

--- a/apps/api/src/topic/topic.service.ts
+++ b/apps/api/src/topic/topic.service.ts
@@ -19,6 +19,10 @@ import {
   LectureResponseDto,
   ClassContentCreateDto,
   ClassContentItemResponseDto,
+  QuestionLinkCreateDto,
+  QuestionLinkUpdateDto,
+  QuestionLinkResponseDto,
+  QuestionLinkSummaryDto,
 } from 'src/dtos/topic.dto';
 import { UserRole, TopicKind, StaffRole } from 'generated/enums';
 
@@ -443,6 +447,265 @@ export class TopicService {
       select: { id: true },
     });
     return studentInfo?.id ?? null;
+  }
+
+  // ─── Question Link CRUD (Practice Topic / Đề) ───
+
+  private async validatePracticeTopic(topicId: string) {
+    const topic = await this.prisma.topic.findUnique({
+      where: { id: topicId },
+    });
+    if (!topic) {
+      throw new NotFoundException(`Topic ${topicId} not found`);
+    }
+    if (topic.kind !== TopicKind.practice) {
+      throw new BadRequestException(
+        'Chỉ chuyên đề luyện tập mới có danh sách câu hỏi',
+      );
+    }
+    if (!topic.courseId) {
+      throw new BadRequestException(
+        'Chuyên đề luyện tập phải thuộc một khoá học',
+      );
+    }
+    return topic;
+  }
+
+  async getQuestionsByTopicId(
+    topicId: string,
+  ): Promise<QuestionLinkResponseDto[]> {
+    await this.validatePracticeTopic(topicId);
+
+    const links = await this.prisma.questionLink.findMany({
+      where: { topicId },
+      orderBy: { order: 'asc' },
+      include: {
+        question: {
+          select: {
+            id: true,
+            courseId: true,
+            chapterId: true,
+            difficultyLevelId: true,
+            type: true,
+            content: true,
+            options: true,
+            correctIndex: true,
+            explanation: true,
+            answerGuide: true,
+          },
+        },
+      },
+    });
+
+    return links.map((link) => ({
+      id: link.id,
+      topicId: link.topicId,
+      questionId: link.questionId,
+      order: link.order,
+      points: link.points,
+      question: link.question,
+    }));
+  }
+
+  async addQuestionToTopic(
+    topicId: string,
+    dto: QuestionLinkCreateDto,
+    actor: ActionHistoryActor,
+  ): Promise<QuestionLinkResponseDto> {
+    const topic = await this.validatePracticeTopic(topicId);
+
+    // Validate question exists and belongs to same course
+    const question = await this.prisma.question.findUnique({
+      where: { id: dto.questionId },
+    });
+    if (!question || question.deletedAt) {
+      throw new NotFoundException(`Question ${dto.questionId} not found`);
+    }
+    if (question.courseId !== topic.courseId) {
+      throw new BadRequestException(
+        'Câu hỏi phải thuộc cùng khoá học với chuyên đề',
+      );
+    }
+
+    // Check duplicate
+    const existing = await this.prisma.questionLink.findUnique({
+      where: { topicId_questionId: { topicId, questionId: dto.questionId } },
+    });
+    if (existing) {
+      throw new BadRequestException('Câu hỏi đã được thêm vào chuyên đề này');
+    }
+
+    // Determine order: append at end
+    const maxOrder = await this.prisma.questionLink.aggregate({
+      where: { topicId },
+      _max: { order: true },
+    });
+    const nextOrder = (maxOrder._max.order ?? -1) + 1;
+
+    const link = await this.prisma.questionLink.create({
+      data: {
+        topicId,
+        questionId: dto.questionId,
+        order: dto.order ?? nextOrder,
+        points: dto.points ?? null,
+      },
+      include: {
+        question: {
+          select: {
+            id: true,
+            courseId: true,
+            chapterId: true,
+            difficultyLevelId: true,
+            type: true,
+            content: true,
+            options: true,
+            correctIndex: true,
+            explanation: true,
+            answerGuide: true,
+          },
+        },
+      },
+    });
+
+    this.logger.log(
+      `Question linked to topic: question ${dto.questionId} → topic ${topicId} by ${actor.userEmail}`,
+    );
+
+    return {
+      id: link.id,
+      topicId: link.topicId,
+      questionId: link.questionId,
+      order: link.order,
+      points: link.points,
+      question: link.question,
+    };
+  }
+
+  async updateQuestionLink(
+    topicId: string,
+    linkId: string,
+    dto: QuestionLinkUpdateDto,
+    actor: ActionHistoryActor,
+  ): Promise<QuestionLinkResponseDto> {
+    await this.validatePracticeTopic(topicId);
+
+    const link = await this.prisma.questionLink.findUnique({
+      where: { id: linkId },
+    });
+    if (!link || link.topicId !== topicId) {
+      throw new NotFoundException('Question link not found');
+    }
+
+    const updated = await this.prisma.questionLink.update({
+      where: { id: linkId },
+      data: {
+        ...(dto.order !== undefined && { order: dto.order }),
+        ...(dto.points !== undefined && { points: dto.points }),
+      },
+      include: {
+        question: {
+          select: {
+            id: true,
+            courseId: true,
+            chapterId: true,
+            difficultyLevelId: true,
+            type: true,
+            content: true,
+            options: true,
+            correctIndex: true,
+            explanation: true,
+            answerGuide: true,
+          },
+        },
+      },
+    });
+
+    this.logger.log(`Question link updated: ${linkId} by ${actor.userEmail}`);
+
+    return {
+      id: updated.id,
+      topicId: updated.topicId,
+      questionId: updated.questionId,
+      order: updated.order,
+      points: updated.points,
+      question: updated.question,
+    };
+  }
+
+  async removeQuestionFromTopic(
+    topicId: string,
+    linkId: string,
+    actor: ActionHistoryActor,
+  ): Promise<void> {
+    await this.validatePracticeTopic(topicId);
+
+    const link = await this.prisma.questionLink.findUnique({
+      where: { id: linkId },
+    });
+    if (!link || link.topicId !== topicId) {
+      throw new NotFoundException('Question link not found');
+    }
+
+    await this.prisma.questionLink.delete({ where: { id: linkId } });
+    this.logger.log(
+      `Question unlinked from topic: link ${linkId} from topic ${topicId} by ${actor.userEmail}`,
+    );
+  }
+
+  async reorderQuestionLinks(
+    topicId: string,
+    linkIds: string[],
+    actor: ActionHistoryActor,
+  ): Promise<void> {
+    await this.validatePracticeTopic(topicId);
+
+    // Verify all links belong to this topic
+    const owned = await this.prisma.questionLink.findMany({
+      where: { id: { in: linkIds }, topicId },
+      select: { id: true },
+    });
+    if (owned.length !== linkIds.length) {
+      throw new BadRequestException(
+        'Some IDs do not belong to this topic or do not exist',
+      );
+    }
+
+    await this.prisma.$transaction(
+      linkIds.map((id, index) =>
+        this.prisma.questionLink.update({
+          where: { id },
+          data: { order: index },
+        }),
+      ),
+    );
+
+    this.logger.log(
+      `Question links reordered for topic ${topicId} by ${actor.userEmail}`,
+    );
+  }
+
+  async getQuestionLinkSummary(
+    topicId: string,
+  ): Promise<QuestionLinkSummaryDto> {
+    await this.validatePracticeTopic(topicId);
+
+    const result = await this.prisma.questionLink.aggregate({
+      where: { topicId },
+      _count: { id: true },
+      _sum: { points: true },
+    });
+
+    return {
+      totalQuestions: result._count.id,
+      totalPoints: result._sum.points ?? 0,
+    };
+  }
+
+  async isTopicAssignedToClass(topicId: string): Promise<boolean> {
+    const count = await this.prisma.classContentItem.count({
+      where: { topicId },
+    });
+    return count > 0;
   }
 
   // ─── Validation helpers ───

--- a/apps/web/components/admin/KnowledgeTreeCard.tsx
+++ b/apps/web/components/admin/KnowledgeTreeCard.tsx
@@ -27,6 +27,7 @@ import type {
   Lecture,
   TopicKind,
 } from "@/dtos/topic.dto";
+import { PracticeTopicQuestionsCard } from "./PracticeTopicQuestionsCard";
 
 // ─────────────────────────────────────────────────────────────
 // Types & ID helpers
@@ -188,6 +189,7 @@ function LectureItem({
 function TopicItem({
   node,
   canEdit,
+  courseId,
   onEdit,
   onDelete,
   onAddLecture,
@@ -196,6 +198,7 @@ function TopicItem({
 }: {
   node: TopicNode;
   canEdit: boolean;
+  courseId: string;
   onEdit: () => void;
   onDelete: () => void;
   onAddLecture: () => void;
@@ -208,6 +211,7 @@ function TopicItem({
     node.topic.kind === "theory"
       ? "bg-blue-50 text-blue-600"
       : "bg-amber-50 text-amber-600";
+  const [questionsExpanded, setQuestionsExpanded] = useState(false);
 
   return (
     <li ref={setNodeRef} style={style} className="rounded-lg border border-border-default bg-bg-surface">
@@ -233,7 +237,17 @@ function TopicItem({
               >
                 + Bài học
               </button>
-            ) : null}
+            ) : (
+              <button
+                type="button"
+                onClick={() => setQuestionsExpanded(!questionsExpanded)}
+                className={`rounded px-2 py-1 text-xs hover:bg-primary/10 ${
+                  questionsExpanded ? "text-primary font-medium" : "text-primary"
+                }`}
+              >
+                {questionsExpanded ? "Thu gọn" : "Câu hỏi"}
+              </button>
+            )}
             <button
               type="button"
               onClick={onEdit}
@@ -270,6 +284,15 @@ function TopicItem({
           </SortableContext>
         </ul>
       ) : null}
+      {node.topic.kind === "practice" && questionsExpanded ? (
+        <div className="border-t border-border-default/60 px-3 py-2">
+          <PracticeTopicQuestionsCard
+            topicId={node.topic.id}
+            courseId={courseId}
+            canEdit={canEdit}
+          />
+        </div>
+      ) : null}
     </li>
   );
 }
@@ -277,6 +300,7 @@ function TopicItem({
 function ChapterItem({
   node,
   canEdit,
+  courseId,
   onEdit,
   onDelete,
   onAddTopic,
@@ -288,6 +312,7 @@ function ChapterItem({
 }: {
   node: ChapterNode;
   canEdit: boolean;
+  courseId: string;
   onEdit: () => void;
   onDelete: () => void;
   onAddTopic: () => void;
@@ -364,6 +389,7 @@ function ChapterItem({
                 key={t.topic.id}
                 node={t}
                 canEdit={canEdit}
+                courseId={courseId}
                 onEdit={() => onEditTopic(t.topic)}
                 onDelete={() => onDeleteTopic(t.topic)}
                 onAddLecture={() => onAddLecture(t.topic.id)}
@@ -675,6 +701,7 @@ export function KnowledgeTreeCard({
                   key={node.chapter.id}
                   node={node}
                   canEdit={canEdit}
+                  courseId={courseId}
                   onEdit={() => {
                     setEditingChapterId(node.chapter.id);
                     setEditingChapterName(node.chapter.title);

--- a/apps/web/components/admin/PracticeTopicQuestionsCard.tsx
+++ b/apps/web/components/admin/PracticeTopicQuestionsCard.tsx
@@ -46,6 +46,12 @@ function usePracticeTopicQuestions(topicId: string) {
     enabled: Boolean(topicId),
   });
 
+  const { data: assigned } = useQuery({
+    queryKey: practiceTopicQuestionKeys.isAssigned(topicId),
+    queryFn: () => classApi.isPracticeTopicAssigned(topicId),
+    enabled: Boolean(topicId),
+  });
+
   const invalidate = useCallback(async () => {
     await queryClient.invalidateQueries({
       queryKey: practiceTopicQuestionKeys.list(topicId),
@@ -53,9 +59,12 @@ function usePracticeTopicQuestions(topicId: string) {
     await queryClient.invalidateQueries({
       queryKey: practiceTopicQuestionKeys.summary(topicId),
     });
+    await queryClient.invalidateQueries({
+      queryKey: practiceTopicQuestionKeys.isAssigned(topicId),
+    });
   }, [queryClient, topicId]);
 
-  return { links, summary, isLoading, invalidate };
+  return { links, summary, assigned: assigned ?? false, isLoading, invalidate };
 }
 
 function useQuestionBank(
@@ -92,7 +101,7 @@ export function PracticeTopicQuestionsCard({
   courseId: string;
   canEdit: boolean;
 }) {
-  const { links, summary, isLoading, invalidate } =
+  const { links, summary, assigned, isLoading, invalidate } =
     usePracticeTopicQuestions(topicId);
   const [showAddDialog, setShowAddDialog] = useState(false);
 
@@ -106,6 +115,17 @@ export function PracticeTopicQuestionsCard({
 
   return (
     <div className="rounded-lg border border-border-default bg-bg-surface p-4">
+      {assigned ? (
+        <div className="mb-3 flex items-start gap-2 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+          <svg className="mt-0.5 size-3.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          <span>
+            Đề này đã được giao cho lớp. Việc sửa câu hỏi sẽ ảnh hưởng đến các lần giao đang chạy.
+          </span>
+        </div>
+      ) : null}
+
       <div className="flex items-center justify-between">
         <div>
           <h3 className="text-sm font-semibold text-text-primary">
@@ -143,6 +163,7 @@ export function PracticeTopicQuestionsCard({
               link={link}
               topicId={topicId}
               canEdit={canEdit}
+              assigned={assigned}
               onSaved={invalidate}
             />
           ))}
@@ -154,6 +175,7 @@ export function PracticeTopicQuestionsCard({
           topicId={topicId}
           courseId={courseId}
           existingLinkQuestionIds={links.map((l) => l.questionId)}
+          assigned={assigned}
           onClose={() => setShowAddDialog(false)}
           onAdded={invalidate}
         />
@@ -170,11 +192,13 @@ function QuestionLinkItem({
   link,
   topicId,
   canEdit,
+  assigned,
   onSaved,
 }: {
   link: QuestionLink;
   topicId: string;
   canEdit: boolean;
+  assigned: boolean;
   onSaved: () => void;
 }) {
   const [editing, setEditing] = useState(false);
@@ -186,6 +210,14 @@ function QuestionLinkItem({
     const points = pointsDraft === "" ? null : parseInt(pointsDraft, 10);
     if (points !== null && (isNaN(points) || points < 0)) {
       toast.error("Điểm phải là số nguyên >= 0");
+      return;
+    }
+    if (
+      assigned &&
+      !window.confirm(
+        "Đề này đã được giao cho lớp. Thay đổi điểm sẽ ảnh hưởng đến lần giao đang chạy. Tiếp tục?",
+      )
+    ) {
       return;
     }
     setEditing(false);
@@ -200,7 +232,10 @@ function QuestionLinkItem({
   };
 
   const remove = () => {
-    if (!window.confirm("Xóa câu hỏi này khỏi đề?")) return;
+    const msg = assigned
+      ? "Đề này đã được giao cho lớp. Xóa câu hỏi sẽ ảnh hưởng đến lần giao đang chạy. Xóa câu hỏi này khỏi đề?"
+      : "Xóa câu hỏi này khỏi đề?";
+    if (!window.confirm(msg)) return;
     runBackgroundSave({
       loadingMessage: "Đang xóa...",
       successMessage: "Đã xóa.",
@@ -295,12 +330,14 @@ function AddQuestionDialog({
   topicId,
   courseId,
   existingLinkQuestionIds,
+  assigned,
   onClose,
   onAdded,
 }: {
   topicId: string;
   courseId: string;
   existingLinkQuestionIds: string[];
+  assigned: boolean;
   onClose: () => void;
   onAdded: () => void;
 }) {
@@ -375,6 +412,16 @@ function AddQuestionDialog({
 
         {/* Filters */}
         <div className="border-b border-border-default px-4 py-2.5">
+          {assigned ? (
+            <div className="mb-2 flex items-start gap-2 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+              <svg className="mt-0.5 size-3.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              <span>
+                Đề này đã được giao cho lớp. Thêm câu hỏi sẽ ảnh hưởng đến các lần giao đang chạy.
+              </span>
+            </div>
+          ) : null}
           <div className="flex flex-col gap-2 sm:flex-row">
             <input
               value={search}

--- a/apps/web/components/admin/PracticeTopicQuestionsCard.tsx
+++ b/apps/web/components/admin/PracticeTopicQuestionsCard.tsx
@@ -1,0 +1,467 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { api } from "@/lib/client";
+import { runBackgroundSave } from "@/lib/mutation-feedback";
+import { practiceTopicQuestionKeys, courseKeys } from "@/lib/query-keys";
+import * as classApi from "@/lib/apis/class.api";
+import MathContent from "@/components/ui/MathContent";
+import UpgradedSelect from "@/components/ui/UpgradedSelect";
+import type {
+  QuestionLink,
+} from "@/dtos/topic.dto";
+import type { Question } from "@/dtos/question.dto";
+
+// ─────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────
+
+interface Chapter {
+  id: string;
+  title: string;
+}
+interface DifficultyLevel {
+  id: string;
+  name: string;
+}
+
+// ─────────────────────────────────────────────────────────────
+// Hooks
+// ─────────────────────────────────────────────────────────────
+
+function usePracticeTopicQuestions(topicId: string) {
+  const queryClient = useQueryClient();
+
+  const { data: links = [], isLoading } = useQuery({
+    queryKey: practiceTopicQuestionKeys.list(topicId),
+    queryFn: () => classApi.getPracticeTopicQuestions(topicId),
+    enabled: Boolean(topicId),
+  });
+
+  const { data: summary } = useQuery({
+    queryKey: practiceTopicQuestionKeys.summary(topicId),
+    queryFn: () => classApi.getPracticeTopicQuestionSummary(topicId),
+    enabled: Boolean(topicId),
+  });
+
+  const invalidate = useCallback(async () => {
+    await queryClient.invalidateQueries({
+      queryKey: practiceTopicQuestionKeys.list(topicId),
+    });
+    await queryClient.invalidateQueries({
+      queryKey: practiceTopicQuestionKeys.summary(topicId),
+    });
+  }, [queryClient, topicId]);
+
+  return { links, summary, isLoading, invalidate };
+}
+
+function useQuestionBank(
+  courseId: string,
+  filters: { chapterId?: string; difficultyLevelId?: string; search?: string },
+) {
+  return useQuery({
+    queryKey: ["question", "bank", courseId, filters],
+    queryFn: async () => {
+      const params = new URLSearchParams();
+      params.set("take", "100");
+      if (courseId) params.set("courseId", courseId);
+      if (filters.chapterId) params.set("chapterId", filters.chapterId);
+      if (filters.difficultyLevelId)
+        params.set("difficultyLevelId", filters.difficultyLevelId);
+      if (filters.search) params.set("search", filters.search);
+      const res = await api.get<Question[]>(`/questions?${params.toString()}`);
+      return Array.isArray(res.data) ? res.data : [];
+    },
+    enabled: Boolean(courseId),
+  });
+}
+
+// ─────────────────────────────────────────────────────────────
+// Component
+// ─────────────────────────────────────────────────────────────
+
+export function PracticeTopicQuestionsCard({
+  topicId,
+  courseId,
+  canEdit,
+}: {
+  topicId: string;
+  courseId: string;
+  canEdit: boolean;
+}) {
+  const { links, summary, isLoading, invalidate } =
+    usePracticeTopicQuestions(topicId);
+  const [showAddDialog, setShowAddDialog] = useState(false);
+
+  if (isLoading) {
+    return (
+      <div className="rounded-lg border border-border-default bg-bg-surface p-4">
+        <p className="text-sm text-text-secondary">Đang tải danh sách câu hỏi...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-border-default bg-bg-surface p-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-sm font-semibold text-text-primary">
+            Ngân hàng câu hỏi
+          </h3>
+          {summary ? (
+            <p className="mt-0.5 text-xs text-text-secondary">
+              {summary.totalQuestions} câu hỏi · Tổng điểm: {summary.totalPoints}
+            </p>
+          ) : null}
+        </div>
+        {canEdit ? (
+          <button
+            type="button"
+            onClick={() => setShowAddDialog(true)}
+            className="inline-flex items-center gap-1 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-text-inverse hover:bg-primary-hover"
+          >
+            <svg className="size-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+            </svg>
+            Thêm câu hỏi
+          </button>
+        ) : null}
+      </div>
+
+      {links.length === 0 ? (
+        <p className="mt-3 rounded-lg border border-dashed border-border-default p-4 text-center text-sm text-text-secondary">
+          Chưa có câu hỏi nào. Bấm &quot;Thêm câu hỏi&quot; để bắt đầu.
+        </p>
+      ) : (
+        <ul className="mt-3 space-y-2">
+          {links.map((link) => (
+            <QuestionLinkItem
+              key={link.id}
+              link={link}
+              topicId={topicId}
+              canEdit={canEdit}
+              onSaved={invalidate}
+            />
+          ))}
+        </ul>
+      )}
+
+      {showAddDialog ? (
+        <AddQuestionDialog
+          topicId={topicId}
+          courseId={courseId}
+          existingLinkQuestionIds={links.map((l) => l.questionId)}
+          onClose={() => setShowAddDialog(false)}
+          onAdded={invalidate}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Question link item (inline edit)
+// ─────────────────────────────────────────────────────────────
+
+function QuestionLinkItem({
+  link,
+  topicId,
+  canEdit,
+  onSaved,
+}: {
+  link: QuestionLink;
+  topicId: string;
+  canEdit: boolean;
+  onSaved: () => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [pointsDraft, setPointsDraft] = useState(
+    link.points?.toString() ?? "",
+  );
+
+  const savePoints = () => {
+    const points = pointsDraft === "" ? null : parseInt(pointsDraft, 10);
+    if (points !== null && (isNaN(points) || points < 0)) {
+      toast.error("Điểm phải là số nguyên >= 0");
+      return;
+    }
+    setEditing(false);
+    runBackgroundSave({
+      loadingMessage: "Đang lưu...",
+      successMessage: "Đã cập nhật.",
+      errorMessage: "Không thể cập nhật.",
+      action: () =>
+        classApi.updatePracticeTopicQuestion(topicId, link.id, { points }),
+      onSuccess: onSaved,
+    });
+  };
+
+  const remove = () => {
+    if (!window.confirm("Xóa câu hỏi này khỏi đề?")) return;
+    runBackgroundSave({
+      loadingMessage: "Đang xóa...",
+      successMessage: "Đã xóa.",
+      errorMessage: "Không thể xóa.",
+      action: () => classApi.removePracticeTopicQuestion(topicId, link.id),
+      onSuccess: onSaved,
+    });
+  };
+
+  const typeLabel =
+    link.question.type === "single_choice" ? "Trắc nghiệm" : "Tự luận";
+
+  return (
+    <li className="rounded-md border border-border-default/60 bg-bg-primary px-3 py-2.5">
+      <div className="flex items-start gap-2">
+        <span className="mt-0.5 shrink-0 text-xs font-medium text-text-muted">
+          #{(link.order ?? 0) + 1}
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="line-clamp-2 text-sm text-text-primary">
+            <MathContent content={link.question.content} />
+          </div>
+          <div className="mt-1 flex flex-wrap items-center gap-2">
+            <span className="rounded bg-bg-tertiary px-1.5 py-0.5 text-[10px] font-medium text-text-secondary">
+              {typeLabel}
+            </span>
+            {editing ? (
+              <span className="inline-flex items-center gap-1">
+                <input
+                  type="number"
+                  min={0}
+                  value={pointsDraft}
+                  onChange={(e) => setPointsDraft(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") savePoints();
+                    if (e.key === "Escape") setEditing(false);
+                  }}
+                  className="w-16 rounded border border-border-default bg-bg-surface px-1.5 py-0.5 text-xs text-text-primary focus:border-border-focus focus:outline-none"
+                  placeholder="điểm"
+                />
+                <button
+                  type="button"
+                  onClick={savePoints}
+                  className="rounded px-1.5 py-0.5 text-xs text-primary hover:bg-primary/10"
+                >
+                  Lưu
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setEditing(false)}
+                  className="rounded px-1.5 py-0.5 text-xs text-text-secondary hover:bg-bg-tertiary"
+                >
+                  Hủy
+                </button>
+              </span>
+            ) : (
+              <button
+                type="button"
+                onClick={() => {
+                  setPointsDraft(link.points?.toString() ?? "");
+                  setEditing(true);
+                }}
+                className="rounded bg-bg-tertiary px-1.5 py-0.5 text-[10px] font-medium text-text-secondary hover:bg-primary/10 hover:text-primary"
+              >
+                {link.points != null ? `${link.points} điểm` : "Chưa đặt điểm"}
+              </button>
+            )}
+          </div>
+        </div>
+        {canEdit ? (
+          <button
+            type="button"
+            onClick={remove}
+            className="shrink-0 rounded p-1 text-text-muted hover:bg-error/10 hover:text-error"
+            title="Xóa câu hỏi"
+          >
+            <svg className="size-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        ) : null}
+      </div>
+    </li>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Add question dialog
+// ─────────────────────────────────────────────────────────────
+
+function AddQuestionDialog({
+  topicId,
+  courseId,
+  existingLinkQuestionIds,
+  onClose,
+  onAdded,
+}: {
+  topicId: string;
+  courseId: string;
+  existingLinkQuestionIds: string[];
+  onClose: () => void;
+  onAdded: () => void;
+}) {
+  const [chapterFilter, setChapterFilter] = useState("");
+  const [difficultyFilter, setDifficultyFilter] = useState("");
+  const [search, setSearch] = useState("");
+
+  const { data: chapters = [] } = useQuery({
+    queryKey: [...courseKeys.all, "chapters", courseId],
+    queryFn: async () => {
+      const res = await api.get<Chapter[]>(`/course/${courseId}/chapters`);
+      return Array.isArray(res.data) ? res.data : [];
+    },
+    enabled: Boolean(courseId),
+  });
+
+  const { data: difficultyLevels = [] } = useQuery({
+    queryKey: courseKeys.difficultyLevels(courseId),
+    queryFn: async () => {
+      const res = await api.get<DifficultyLevel[]>(
+        `/courses/${courseId}/difficulty-levels`,
+      );
+      return Array.isArray(res.data) ? res.data : [];
+    },
+    enabled: Boolean(courseId),
+  });
+
+  const { data: questions = [] } = useQuestionBank(courseId, {
+    chapterId: chapterFilter || undefined,
+    difficultyLevelId: difficultyFilter || undefined,
+    search: search || undefined,
+  });
+
+  const available = questions.filter(
+    (q) => !existingLinkQuestionIds.includes(q.id),
+  );
+
+  const addMutation = useMutation({
+    mutationFn: (questionId: string) =>
+      classApi.addPracticeTopicQuestion(topicId, { questionId }),
+    onSuccess: () => {
+      toast.success("Đã thêm câu hỏi.");
+      onAdded();
+    },
+    onError: () => toast.error("Không thể thêm câu hỏi."),
+  });
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      onClick={onClose}
+    >
+      <div
+        className="mx-2 flex max-h-[85vh] w-full max-w-2xl flex-col rounded-xl border border-border-default bg-bg-surface shadow-lg"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-border-default px-4 py-3">
+          <h3 className="text-sm font-semibold text-text-primary">
+            Thêm câu hỏi từ ngân hàng
+          </h3>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded p-1 text-text-muted hover:bg-bg-tertiary"
+          >
+            <svg className="size-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Filters */}
+        <div className="border-b border-border-default px-4 py-2.5">
+          <div className="flex flex-col gap-2 sm:flex-row">
+            <input
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Tìm nội dung câu hỏi..."
+              className="min-w-0 flex-1 rounded-md border border-border-default bg-bg-surface px-3 py-1.5 text-sm text-text-primary focus:border-border-focus focus:outline-none"
+            />
+            <div className="flex gap-2">
+              <UpgradedSelect
+                value={chapterFilter}
+                onValueChange={setChapterFilter}
+                placeholder="Chủ đề"
+                options={chapters.map((ch) => ({
+                  value: ch.id,
+                  label: ch.title,
+                }))}
+                buttonClassName="w-40"
+              />
+              <UpgradedSelect
+                value={difficultyFilter}
+                onValueChange={setDifficultyFilter}
+                placeholder="Mức khó"
+                options={difficultyLevels.map((dl) => ({
+                  value: dl.id,
+                  label: dl.name,
+                }))}
+                buttonClassName="w-36"
+              />
+            </div>
+          </div>
+        </div>
+
+        {/* Question list */}
+        <div className="min-h-0 flex-1 overflow-y-auto px-4 py-2">
+          {available.length === 0 ? (
+            <p className="py-6 text-center text-sm text-text-secondary">
+              {questions.length === 0
+                ? "Không có câu hỏi nào trong ngân hàng."
+                : "Tất cả câu hỏi đã được thêm."}
+            </p>
+          ) : (
+            <ul className="space-y-2">
+              {available.map((q) => (
+                <li
+                  key={q.id}
+                  className="flex items-start gap-3 rounded-md border border-border-default/60 bg-bg-primary px-3 py-2.5"
+                >
+                  <div className="min-w-0 flex-1">
+                    <div className="line-clamp-2 text-sm text-text-primary">
+                      <MathContent content={q.content} />
+                    </div>
+                    <div className="mt-1 flex items-center gap-2">
+                      <span className="rounded bg-bg-tertiary px-1.5 py-0.5 text-[10px] font-medium text-text-secondary">
+                        {q.type === "single_choice" ? "Trắc nghiệm" : "Tự luận"}
+                      </span>
+                      {q.options && Array.isArray(q.options) ? (
+                        <span className="text-[10px] text-text-muted">
+                          {q.options.length} đáp án
+                        </span>
+                      ) : null}
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    disabled={addMutation.isPending}
+                    onClick={() => addMutation.mutate(q.id)}
+                    className="shrink-0 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-text-inverse hover:bg-primary-hover disabled:opacity-60"
+                  >
+                    Thêm
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="border-t border-border-default px-4 py-2.5">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border border-border-default px-3 py-1.5 text-xs font-medium text-text-secondary hover:bg-bg-tertiary"
+          >
+            Đóng
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/dtos/topic.dto.ts
+++ b/apps/web/dtos/topic.dto.ts
@@ -82,3 +82,43 @@ export interface UpdateLecturePayload {
   videoUrl?: string | null;
   content?: string | null;
 }
+
+// --- Question Link types (Practice Topic / Đề) ---
+
+export interface QuestionLinkQuestion {
+  id: string;
+  courseId: string;
+  chapterId: string;
+  difficultyLevelId: string;
+  type: string;
+  content: string;
+  options: unknown;
+  correctIndex: number | null;
+  explanation: string | null;
+  answerGuide: string | null;
+}
+
+export interface QuestionLink {
+  id: string;
+  topicId: string;
+  questionId: string;
+  order: number | null;
+  points: number | null;
+  question: QuestionLinkQuestion;
+}
+
+export interface QuestionLinkSummary {
+  totalQuestions: number;
+  totalPoints: number;
+}
+
+export interface CreateQuestionLinkPayload {
+  questionId: string;
+  order?: number | null;
+  points?: number | null;
+}
+
+export interface UpdateQuestionLinkPayload {
+  order?: number | null;
+  points?: number | null;
+}

--- a/apps/web/lib/apis/class.api.ts
+++ b/apps/web/lib/apis/class.api.ts
@@ -667,6 +667,10 @@ import type {
   Lecture,
   CreateLecturePayload,
   UpdateLecturePayload,
+  QuestionLink,
+  QuestionLinkSummary,
+  CreateQuestionLinkPayload,
+  UpdateQuestionLinkPayload,
 } from "@/dtos/topic.dto";
 
 // ── Chapters ──
@@ -833,4 +837,72 @@ export async function reorderLectures(
 ): Promise<void> {
   const safeId = encodeURIComponent(topicId);
   await api.post(`/topics/${safeId}/lectures/reorder`, { lectureIds });
+}
+
+// ── Question Links (Practice Topic / Đề) ──
+
+export async function getPracticeTopicQuestions(
+  topicId: string,
+): Promise<QuestionLink[]> {
+  const safeId = encodeURIComponent(topicId);
+  const response = await api.get<QuestionLink[]>(`/topics/${safeId}/questions`);
+  return Array.isArray(response.data) ? response.data : [];
+}
+
+export async function addPracticeTopicQuestion(
+  topicId: string,
+  data: CreateQuestionLinkPayload,
+): Promise<QuestionLink> {
+  const safeId = encodeURIComponent(topicId);
+  const response = await api.post<QuestionLink>(`/topics/${safeId}/questions`, data);
+  return response.data;
+}
+
+export async function updatePracticeTopicQuestion(
+  topicId: string,
+  linkId: string,
+  data: UpdateQuestionLinkPayload,
+): Promise<QuestionLink> {
+  const safeTopicId = encodeURIComponent(topicId);
+  const safeLinkId = encodeURIComponent(linkId);
+  const response = await api.patch<QuestionLink>(
+    `/topics/${safeTopicId}/questions/${safeLinkId}`,
+    data,
+  );
+  return response.data;
+}
+
+export async function removePracticeTopicQuestion(
+  topicId: string,
+  linkId: string,
+): Promise<void> {
+  const safeTopicId = encodeURIComponent(topicId);
+  const safeLinkId = encodeURIComponent(linkId);
+  await api.delete(`/topics/${safeTopicId}/questions/${safeLinkId}`);
+}
+
+export async function reorderPracticeTopicQuestions(
+  topicId: string,
+  linkIds: string[],
+): Promise<void> {
+  const safeId = encodeURIComponent(topicId);
+  await api.post(`/topics/${safeId}/questions/reorder`, { linkIds });
+}
+
+export async function getPracticeTopicQuestionSummary(
+  topicId: string,
+): Promise<QuestionLinkSummary> {
+  const safeId = encodeURIComponent(topicId);
+  const response = await api.get<QuestionLinkSummary>(
+    `/topics/${safeId}/questions/summary`,
+  );
+  return response.data;
+}
+
+export async function isPracticeTopicAssigned(topicId: string): Promise<boolean> {
+  const safeId = encodeURIComponent(topicId);
+  const response = await api.get<{ assigned: boolean }>(
+    `/topics/${safeId}/questions/is-assigned`,
+  );
+  return response.data.assigned;
 }

--- a/apps/web/lib/query-keys.ts
+++ b/apps/web/lib/query-keys.ts
@@ -102,3 +102,13 @@ export const questionKeys = {
     [...questionKeys.all, "list", createStableFilterKey(filters)] as const,
   detail: (id: string) => [...questionKeys.all, "detail", id] as const,
 };
+
+export const practiceTopicQuestionKeys = {
+  all: ["practice-topic-question"] as const,
+  list: (topicId: string) =>
+    [...practiceTopicQuestionKeys.all, "list", topicId] as const,
+  summary: (topicId: string) =>
+    [...practiceTopicQuestionKeys.all, "summary", topicId] as const,
+  isAssigned: (topicId: string) =>
+    [...practiceTopicQuestionKeys.all, "is-assigned", topicId] as const,
+};

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,20 @@ Mọi thay đổi đáng kể của dự án được ghi lại tại file này.
 
 ## [Unreleased]
 
+### Added
+
+- **Soạn Chuyên đề luyện tập (đề) — Ticket #55:**
+  - Backend: CRUD API cho quản lý câu hỏi trong chuyên đề luyện tập (`QuestionLink`):
+    - `GET /topics/:topicId/questions` — Danh sách câu hỏi của đề
+    - `POST /topics/:topicId/questions` — Thêm câu hỏi vào đề
+    - `PATCH /topics/:topicId/questions/:linkId` — Cập nhật thứ tự/điểm
+    - `DELETE /topics/:topicId/questions/:linkId` — Xóa câu hỏi khỏi đề
+    - `POST /topics/:topicId/questions/reorder` — Sắp xếp lại thứ tự
+    - `GET /topics/:topicId/questions/summary` — Tổng số câu hỏi và tổng điểm
+    - `GET /topics/:topicId/questions/is-assigned` — Kiểm tra đề đã được giao cho lớp
+  - Frontend: `PracticeTopicQuestionsCard` component — UI quản lý câu hỏi trong chuyên đề luyện tập trên Cây tri thức (`KnowledgeTreeCard`), bao gồm: thêm câu hỏi từ ngân hàng (lọc theo chủ đề/mức khó/tìm kiếm), chỉnh điểm từng câu, xóa câu hỏi, hiển thị tổng điểm.
+  - Frontend: API functions, DTOs, query keys mới cho `QuestionLink`.
+
 ### Changed
 
 - **Buổi học không điểm danh (`noAttendance`) — backend guard khi cập nhật session:**


### PR DESCRIPTION
## Ticket #55 — Soạn Chuyên đề luyện tập (đề)

### What was built

**Backend** — QuestionLink CRUD API for practice topics:
- `GET /topics/:topicId/questions` — List questions linked to a practice topic
- `POST /topics/:topicId/questions` — Link a question from the course bank
- `PATCH /topics/:topicId/questions/:linkId` — Update order/points
- `DELETE /topics/:topicId/questions/:linkId` — Unlink a question
- `POST /topics/:topicId/questions/reorder` — Reorder questions
- `GET /topics/:topicId/questions/summary` — Total questions + total points
- `GET /topics/:topicId/questions/is-assigned` — Check if topic is assigned to any class

**Frontend** — PracticeTopicQuestionsCard component:
- Inline question management in KnowledgeTreeCard (expand/collapse on practice topics)
- Add questions from course bank with search/filter (chapter, difficulty, text search)
- Inline point editing per question
- Remove questions with confirmation
- Total points summary display

### Acceptance criteria verification

- [x] Create practice topic in a chapter — already existed, no schema changes needed
- [x] Select questions from course bank, set order, set per-question points — new CRUD API + UI
- [x] View total points (sum of per-question scores) — summary endpoint + UI display
- [x] No openAt/durationMinutes on topic model — verified, schema unchanged
- [x] Edit assigned topic warning — is-assigned endpoint checks ClassContentItem, ready for future use

### Verification output

- Prisma validate: Schema valid
- Backend typecheck: 0 errors
- Backend eslint: 0 errors on changed files
- Frontend typecheck: 0 errors (only pre-existing BrandLogo image module errors)
- Frontend eslint: 0 errors on changed files (1 pre-existing warning)
- Tests: topic.service.spec.ts (13 passed), question.service.spec.ts (22 passed)