### PR TITLE
feat(#54): Soạn bài học + bài tập ôn nhẹ

### DIFF
--- a/apps/api/prisma/schema/learning.prisma
+++ b/apps/api/prisma/schema/learning.prisma
@@ -406,10 +406,50 @@ model Lecture {
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(6)
 
-  topic     Topic    @relation(fields: [topicId], references: [id], onDelete: Cascade)
+  topic         Topic                @relation(fields: [topicId], references: [id], onDelete: Cascade)
+  quizzes       LectureQuiz[]
+  quizAnswers   LectureQuizAnswer[]
 
   @@index([topicId])
   @@map("lectures")
+}
+
+/// Liên kết câu hỏi từ ngân hàng vào bài học ôn nhẹ.
+model LectureQuiz {
+  id         String   @id @default(uuid())
+  lectureId  String   @map("lecture_id")
+  questionId String   @map("question_id")
+  order      Int      @default(0)
+
+  lecture  Lecture  @relation(fields: [lectureId], references: [id], onDelete: Cascade)
+  question Question @relation(fields: [questionId], references: [id], onDelete: Restrict)
+
+  @@unique([lectureId, questionId])
+  @@index([lectureId])
+  @@index([questionId])
+  @@map("lecture_quizzes")
+}
+
+/// Trả lời bài tập ôn nhẹ — KHÔNG sinh Attempt, KHÔNG tính điểm.
+model LectureQuizAnswer {
+  id          String    @id @default(uuid())
+  lectureId   String    @map("lecture_id")
+  questionId  String    @map("question_id")
+  studentId   String    @map("student_id")
+  choiceIndex Int?      @map("choice_index")
+  essayAnswer String?   @map("essay_answer")
+  createdAt   DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt   DateTime  @updatedAt @map("updated_at") @db.Timestamptz(6)
+
+  lecture  Lecture     @relation(fields: [lectureId], references: [id], onDelete: Cascade)
+  question Question    @relation(fields: [questionId], references: [id], onDelete: Restrict)
+  student  StudentInfo @relation(fields: [studentId], references: [id], onDelete: Cascade)
+
+  @@unique([lectureId, questionId, studentId])
+  @@index([lectureId])
+  @@index([questionId])
+  @@index([studentId])
+  @@map("lecture_quiz_answers")
 }
 
 // Question bank models
@@ -435,7 +475,9 @@ model Question {
   difficultyLevel   CourseDifficultyLevel @relation(fields: [difficultyLevelId], references: [id], onDelete: Restrict)
 
   // future link table – defined later (ticket #55) – keep a back‑relation placeholder
-  questionLinks QuestionLink[] // back‑relation for links to topics
+  questionLinks        QuestionLink[]        // back‑relation for links to topics
+  lectureQuizzes       LectureQuiz[]
+  lectureQuizAnswers   LectureQuizAnswer[]
 
   @@index([courseId])
   @@index([chapterId])

--- a/apps/api/prisma/schema/people.prisma
+++ b/apps/api/prisma/schema/people.prisma
@@ -84,6 +84,7 @@ model StudentInfo {
   achievements              StudentAchievement[]
   galleryItems              StudentGalleryItem[]
   surveyAssessments         ClassSurveyStudentAssessment[]
+  lectureQuizAnswers        LectureQuizAnswer[]
 
   @@map("student_info")
 }

--- a/apps/api/src/dtos/topic.dto.ts
+++ b/apps/api/src/dtos/topic.dto.ts
@@ -273,6 +273,53 @@ export interface QuestionLinkResponseDto {
     type: string;
     content: string;
     options: unknown;
+  };
+}
+
+// --- Lecture Quiz DTOs ---
+
+export class LectureQuizLinkDto {
+  @ApiProperty({
+    description: 'Danh sách ID câu hỏi từ ngân hàng cần gắn vào bài học',
+    type: [String],
+  })
+  @IsArray()
+  @IsString({ each: true })
+  questionIds: string[];
+}
+
+export class LectureQuizAnswerDto {
+  @ApiProperty({ description: 'ID câu hỏi' })
+  @IsString()
+  questionId: string;
+
+  @ApiPropertyOptional({
+    description: 'Chỉ số đáp án chọn (0-based, cho trắc nghiệm)',
+    nullable: true,
+  })
+  @IsOptional()
+  @IsInt()
+  choiceIndex?: number | null;
+
+  @ApiPropertyOptional({
+    description: 'Nội dung trả lời (cho tự luận)',
+    nullable: true,
+  })
+  @IsOptional()
+  @IsString()
+  essayAnswer?: string | null;
+}
+
+export interface LectureQuizResponseDto {
+  id: string;
+  lectureId: string;
+  questionId: string;
+  order: number;
+  question: {
+    id: string;
+    type: string;
+    content: string;
+    options: string[] | null;
     correctIndex: number | null;
     explanation: string | null;
     answerGuide: string | null;
@@ -282,4 +329,15 @@ export interface QuestionLinkResponseDto {
 export interface QuestionLinkSummaryDto {
   totalQuestions: number;
   totalPoints: number;
+}
+
+export interface LectureQuizAnswerResponseDto {
+  id: string;
+  lectureId: string;
+  questionId: string;
+  studentId: string;
+  choiceIndex: number | null;
+  essayAnswer: string | null;
+  createdAt: Date;
+  updatedAt: Date;
 }

--- a/apps/api/src/topic/topic.controller.ts
+++ b/apps/api/src/topic/topic.controller.ts
@@ -40,6 +40,7 @@ import {
   QuestionLinkCreateDto,
   QuestionLinkUpdateDto,
   ReorderQuestionLinksDto,
+  LectureQuizLinkDto,
 } from 'src/dtos/topic.dto';
 import { TopicService } from './topic.service';
 
@@ -514,6 +515,87 @@ export class LectureController {
     @Body('lectureIds') lectureIds: string[],
   ): Promise<void> {
     return this.topicService.reorderLectures(topicId, lectureIds);
+  }
+
+  // ─── Lecture Quiz (admin) ───
+
+  @Post(':lectureId/quizzes')
+  @Roles(UserRole.admin)
+  @AllowStaffRolesOnAdminRoutes(
+    StaffRole.assistant,
+    StaffRole.teacher,
+    StaffRole.lesson_plan,
+    StaffRole.lesson_plan_head,
+  )
+  @ApiOperation({ summary: 'Gắn câu hỏi ôn nhẹ vào bài học' })
+  @ApiParam({ name: 'topicId', description: 'ID chuyên đề' })
+  @ApiParam({ name: 'lectureId', description: 'ID bài học' })
+  @ApiBody({ type: LectureQuizLinkDto })
+  @ApiResponse({ status: 200, description: 'Đã gắn câu hỏi.' })
+  @ApiResponse({ status: 400, description: 'Câu hỏi không thuộc khoá học.' })
+  @ApiResponse({ status: 404, description: 'Bài học không tồn tại.' })
+  async linkQuizQuestions(
+    @CurrentUser() user: JwtPayload,
+    @Param('topicId') topicId: string,
+    @Param('lectureId') lectureId: string,
+    @Body() dto: LectureQuizLinkDto,
+  ): Promise<void> {
+    return this.topicService.linkQuizQuestions(lectureId, dto.questionIds, {
+      userId: user.id,
+      userEmail: user.email,
+      roleType: user.roleType,
+    });
+  }
+
+  @Delete(':lectureId/quizzes/:questionId')
+  @Roles(UserRole.admin)
+  @AllowStaffRolesOnAdminRoutes(
+    StaffRole.assistant,
+    StaffRole.teacher,
+    StaffRole.lesson_plan,
+    StaffRole.lesson_plan_head,
+  )
+  @ApiOperation({ summary: 'Gỡ câu hỏi ôn nhẹ khỏi bài học' })
+  @ApiParam({ name: 'topicId', description: 'ID chuyên đề' })
+  @ApiParam({ name: 'lectureId', description: 'ID bài học' })
+  @ApiParam({ name: 'questionId', description: 'ID câu hỏi' })
+  @ApiResponse({ status: 200, description: 'Đã gỡ câu hỏi.' })
+  @ApiResponse({ status: 404, description: 'Câu hỏi chưa được gắn.' })
+  async unlinkQuizQuestion(
+    @CurrentUser() user: JwtPayload,
+    @Param('topicId') topicId: string,
+    @Param('lectureId') lectureId: string,
+    @Param('questionId') questionId: string,
+  ): Promise<void> {
+    return this.topicService.unlinkQuizQuestion(lectureId, questionId, {
+      userId: user.id,
+      userEmail: user.email,
+      roleType: user.roleType,
+    });
+  }
+
+  @Get(':lectureId/quizzes')
+  @Roles(UserRole.admin, UserRole.student)
+  @AllowStaffRolesOnAdminRoutes(
+    StaffRole.assistant,
+    StaffRole.teacher,
+    StaffRole.lesson_plan,
+    StaffRole.lesson_plan_head,
+  )
+  @ApiOperation({ summary: 'Danh sách câu hỏi ôn nhẹ của bài học' })
+  @ApiParam({ name: 'topicId', description: 'ID chuyên đề' })
+  @ApiParam({ name: 'lectureId', description: 'ID bài học' })
+  @ApiResponse({ status: 200, description: 'Danh sách câu hỏi.' })
+  async getLectureQuizzes(
+    @CurrentUser() user: JwtPayload,
+    @Param('topicId') topicId: string,
+    @Param('lectureId') lectureId: string,
+  ) {
+    // Students get questions without correctIndex
+    if (user.roleType === UserRole.student) {
+      return this.topicService.getLectureQuizzesForStudent(lectureId);
+    }
+    return this.topicService.getLectureQuizzes(lectureId);
   }
 }
 

--- a/apps/api/src/topic/topic.service.spec.ts
+++ b/apps/api/src/topic/topic.service.spec.ts
@@ -796,4 +796,210 @@ describe('TopicService — ClassContent methods', () => {
       });
     });
   });
+
+  describe('Lecture Quiz', () => {
+    let quizService: TopicService;
+    let mockActionHistory: Record<string, any>;
+
+    const adminActor = {
+      userId: 'user-admin-1',
+      userEmail: 'admin@test.com',
+      roleType: UserRole.admin,
+    };
+
+    const mockLecture = {
+      id: 'lecture-1',
+      topicId: 'topic-theory-1',
+      title: 'Bài học 1',
+      videoUrl: null,
+      content: null,
+      topic: { courseId: 'course-1' },
+    };
+
+    const mockQuestion = {
+      id: 'q-1',
+      courseId: 'course-1',
+      type: 'single_choice',
+      content: 'Câu hỏi test',
+      options: ['A', 'B', 'C'],
+      correctIndex: 0,
+      explanation: null,
+      answerGuide: null,
+      deletedAt: null,
+    };
+
+    const mockQuizLink = {
+      id: 'quiz-1',
+      lectureId: 'lecture-1',
+      questionId: 'q-1',
+      order: 0,
+      question: mockQuestion,
+    };
+
+    beforeEach(() => {
+      mockPrisma.lecture = {
+        findUnique: jest.fn(),
+      };
+      mockPrisma.question = {
+        findMany: jest.fn(),
+      };
+      mockPrisma.lectureQuiz = {
+        findUnique: jest.fn(),
+        findMany: jest.fn(),
+        create: jest.fn(),
+        delete: jest.fn(),
+        aggregate: jest.fn(),
+      };
+      mockPrisma.lectureQuizAnswer = {
+        upsert: jest.fn(),
+        findMany: jest.fn(),
+      };
+      mockActionHistory = {
+        recordCreate: jest.fn().mockResolvedValue(undefined),
+        recordDelete: jest.fn().mockResolvedValue(undefined),
+      };
+      quizService = new TopicService(
+        mockPrisma as any,
+        mockActionHistory as any,
+      );
+    });
+
+    describe('linkQuizQuestions', () => {
+      it('should link questions not already linked and record audit history', async () => {
+        mockPrisma.lecture.findUnique.mockResolvedValue(mockLecture);
+        mockPrisma.question.findMany.mockResolvedValue([mockQuestion]);
+        mockPrisma.lectureQuiz.aggregate.mockResolvedValue({
+          _max: { order: null },
+        });
+        mockPrisma.lectureQuiz.findUnique.mockResolvedValue(null);
+        mockPrisma.lectureQuiz.create.mockResolvedValue(mockQuizLink);
+
+        await quizService.linkQuizQuestions('lecture-1', ['q-1'], adminActor);
+
+        expect(mockPrisma.lectureQuiz.create).toHaveBeenCalledWith({
+          data: { lectureId: 'lecture-1', questionId: 'q-1', order: 0 },
+        });
+        expect(mockActionHistory.recordCreate).toHaveBeenCalledTimes(1);
+      });
+
+      it('should throw if lecture not found', async () => {
+        mockPrisma.lecture.findUnique.mockResolvedValue(null);
+
+        await expect(
+          quizService.linkQuizQuestions('lecture-missing', ['q-1'], adminActor),
+        ).rejects.toThrow(NotFoundException);
+      });
+
+      it('should throw if some questions do not belong to lecture course', async () => {
+        mockPrisma.lecture.findUnique.mockResolvedValue(mockLecture);
+        mockPrisma.question.findMany.mockResolvedValue([]);
+
+        await expect(
+          quizService.linkQuizQuestions('lecture-1', ['q-foreign'], adminActor),
+        ).rejects.toThrow(BadRequestException);
+      });
+
+      it('should skip questions already linked without creating duplicates', async () => {
+        mockPrisma.lecture.findUnique.mockResolvedValue(mockLecture);
+        mockPrisma.question.findMany.mockResolvedValue([mockQuestion]);
+        mockPrisma.lectureQuiz.aggregate.mockResolvedValue({
+          _max: { order: 0 },
+        });
+        mockPrisma.lectureQuiz.findUnique.mockResolvedValue(mockQuizLink);
+
+        await quizService.linkQuizQuestions('lecture-1', ['q-1'], adminActor);
+
+        expect(mockPrisma.lectureQuiz.create).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('unlinkQuizQuestion', () => {
+      it('should delete the link and record audit history', async () => {
+        mockPrisma.lectureQuiz.findUnique.mockResolvedValue(mockQuizLink);
+        mockPrisma.lectureQuiz.delete.mockResolvedValue({});
+
+        await quizService.unlinkQuizQuestion('lecture-1', 'q-1', adminActor);
+
+        expect(mockPrisma.lectureQuiz.delete).toHaveBeenCalledWith({
+          where: {
+            lectureId_questionId: { lectureId: 'lecture-1', questionId: 'q-1' },
+          },
+        });
+        expect(mockActionHistory.recordDelete).toHaveBeenCalledTimes(1);
+      });
+
+      it('should throw if link not found', async () => {
+        mockPrisma.lectureQuiz.findUnique.mockResolvedValue(null);
+
+        await expect(
+          quizService.unlinkQuizQuestion('lecture-1', 'q-missing', adminActor),
+        ).rejects.toThrow(NotFoundException);
+      });
+    });
+
+    describe('submitQuizAnswers', () => {
+      it('should upsert answers and return them with correctIndex for review', async () => {
+        mockPrisma.lecture.findUnique.mockResolvedValue(mockLecture);
+        mockPrisma.lectureQuiz.findMany.mockResolvedValue([
+          { questionId: 'q-1' },
+        ]);
+        mockPrisma.lectureQuizAnswer.upsert.mockResolvedValue({});
+        mockPrisma.lectureQuizAnswer.findMany.mockResolvedValue([
+          {
+            id: 'ans-1',
+            questionId: 'q-1',
+            choiceIndex: 0,
+            question: mockQuestion,
+          },
+        ]);
+
+        const result = await quizService.submitQuizAnswers(
+          'lecture-1',
+          'student-1',
+          [{ questionId: 'q-1', choiceIndex: 0, essayAnswer: null }],
+        );
+
+        expect(mockPrisma.lectureQuizAnswer.upsert).toHaveBeenCalledTimes(1);
+        expect(result).toHaveLength(1);
+        expect(result[0].question.correctIndex).toBe(0);
+      });
+
+      it('should throw if answer references a question not linked to the lecture', async () => {
+        mockPrisma.lecture.findUnique.mockResolvedValue(mockLecture);
+        mockPrisma.lectureQuiz.findMany.mockResolvedValue([
+          { questionId: 'q-1' },
+        ]);
+
+        await expect(
+          quizService.submitQuizAnswers('lecture-1', 'student-1', [
+            { questionId: 'q-foreign', choiceIndex: 0 },
+          ]),
+        ).rejects.toThrow(BadRequestException);
+      });
+    });
+
+    describe('getQuizAnswers', () => {
+      it('should return saved answers for the student', async () => {
+        mockPrisma.lectureQuizAnswer.findMany.mockResolvedValue([
+          {
+            id: 'ans-1',
+            questionId: 'q-1',
+            choiceIndex: 0,
+            question: mockQuestion,
+          },
+        ]);
+
+        const result = await quizService.getQuizAnswers(
+          'lecture-1',
+          'student-1',
+        );
+
+        expect(result).toHaveLength(1);
+        expect(mockPrisma.lectureQuizAnswer.findMany).toHaveBeenCalledWith({
+          where: { lectureId: 'lecture-1', studentId: 'student-1' },
+          include: expect.any(Object),
+        });
+      });
+    });
+  });
 });

--- a/apps/api/src/topic/topic.service.ts
+++ b/apps/api/src/topic/topic.service.ts
@@ -437,6 +437,240 @@ export class TopicService {
     await this.prisma.$transaction(updates);
   }
 
+  // ─── Lecture Quiz ───
+
+  async linkQuizQuestions(
+    lectureId: string,
+    questionIds: string[],
+    actor: ActionHistoryActor,
+  ): Promise<void> {
+    const lecture = await this.prisma.lecture.findUnique({
+      where: { id: lectureId },
+      include: { topic: { select: { courseId: true } } },
+    });
+    if (!lecture) {
+      throw new NotFoundException(`Lecture ${lectureId} not found`);
+    }
+
+    // Validate questions belong to the same course
+    if (lecture.topic.courseId) {
+      const questions = await this.prisma.question.findMany({
+        where: {
+          id: { in: questionIds },
+          courseId: lecture.topic.courseId,
+          deletedAt: null,
+        },
+        select: { id: true },
+      });
+      if (questions.length !== questionIds.length) {
+        throw new BadRequestException(
+          'Một số câu hỏi không thuộc khoá học này',
+        );
+      }
+    }
+
+    // Get current max order
+    const maxOrder = await this.prisma.lectureQuiz.aggregate({
+      where: { lectureId },
+      _max: { order: true },
+    });
+    let nextOrder = (maxOrder._max.order ?? -1) + 1;
+
+    await this.prisma.$transaction(async (tx) => {
+      for (const questionId of questionIds) {
+        // Skip if already linked
+        const existing = await tx.lectureQuiz.findUnique({
+          where: { lectureId_questionId: { lectureId, questionId } },
+        });
+        if (!existing) {
+          await tx.lectureQuiz.create({
+            data: { lectureId, questionId, order: nextOrder++ },
+          });
+        }
+      }
+
+      await this.actionHistory.recordCreate(tx, {
+        entityType: 'lecture_quiz',
+        entityId: lectureId,
+        actor,
+        afterValue: { lectureId, questionIds },
+      });
+    });
+
+    this.logger.log(
+      `Quiz questions linked to lecture ${lectureId} by ${actor.userEmail}`,
+    );
+  }
+
+  async unlinkQuizQuestion(
+    lectureId: string,
+    questionId: string,
+    actor: ActionHistoryActor,
+  ): Promise<void> {
+    const link = await this.prisma.lectureQuiz.findUnique({
+      where: { lectureId_questionId: { lectureId, questionId } },
+    });
+    if (!link) {
+      throw new NotFoundException('Câu hỏi chưa được gắn vào bài học này');
+    }
+
+    await this.prisma.$transaction(async (tx) => {
+      await tx.lectureQuiz.delete({
+        where: { lectureId_questionId: { lectureId, questionId } },
+      });
+
+      await this.actionHistory.recordDelete(tx, {
+        entityType: 'lecture_quiz',
+        entityId: lectureId,
+        actor,
+        beforeValue: link,
+      });
+    });
+
+    this.logger.log(
+      `Quiz question ${questionId} unlinked from lecture ${lectureId} by ${actor.userEmail}`,
+    );
+  }
+
+  async getLectureQuizzes(lectureId: string) {
+    await this.getLectureById(lectureId); // validate exists
+
+    return this.prisma.lectureQuiz.findMany({
+      where: { lectureId },
+      orderBy: { order: 'asc' },
+      include: {
+        question: {
+          select: {
+            id: true,
+            type: true,
+            content: true,
+            options: true,
+            correctIndex: true,
+            explanation: true,
+            answerGuide: true,
+          },
+        },
+      },
+    });
+  }
+
+  async getLectureQuizzesForStudent(lectureId: string) {
+    await this.getLectureById(lectureId); // validate exists
+
+    // Students see questions without correctIndex (revealed only after submission)
+    const quizzes = await this.prisma.lectureQuiz.findMany({
+      where: { lectureId },
+      orderBy: { order: 'asc' },
+      include: {
+        question: {
+          select: {
+            id: true,
+            type: true,
+            content: true,
+            options: true,
+            explanation: true,
+            answerGuide: true,
+          },
+        },
+      },
+    });
+
+    return quizzes.map((q) => ({
+      ...q,
+      question: { ...q.question, correctIndex: null },
+    }));
+  }
+
+  async submitQuizAnswers(
+    lectureId: string,
+    studentId: string,
+    answers: {
+      questionId: string;
+      choiceIndex?: number | null;
+      essayAnswer?: string | null;
+    }[],
+  ) {
+    await this.getLectureById(lectureId); // validate exists
+
+    // Verify all questions are linked to this lecture
+    const linkedQuestionIds = (
+      await this.prisma.lectureQuiz.findMany({
+        where: { lectureId },
+        select: { questionId: true },
+      })
+    ).map((q) => q.questionId);
+
+    const invalid = answers.filter(
+      (a) => !linkedQuestionIds.includes(a.questionId),
+    );
+    if (invalid.length) {
+      throw new BadRequestException('Một số câu hỏi không thuộc bài học này');
+    }
+
+    // Upsert answers
+    await this.prisma.$transaction(
+      answers.map((a) =>
+        this.prisma.lectureQuizAnswer.upsert({
+          where: {
+            lectureId_questionId_studentId: {
+              lectureId,
+              questionId: a.questionId,
+              studentId,
+            },
+          },
+          create: {
+            lectureId,
+            questionId: a.questionId,
+            studentId,
+            choiceIndex: a.choiceIndex ?? null,
+            essayAnswer: a.essayAnswer ?? null,
+          },
+          update: {
+            choiceIndex: a.choiceIndex ?? null,
+            essayAnswer: a.essayAnswer ?? null,
+          },
+        }),
+      ),
+    );
+
+    // Return answers with correctIndex for review
+    return this.prisma.lectureQuizAnswer.findMany({
+      where: { lectureId, studentId },
+      include: {
+        question: {
+          select: {
+            id: true,
+            type: true,
+            content: true,
+            options: true,
+            correctIndex: true,
+            explanation: true,
+            answerGuide: true,
+          },
+        },
+      },
+    });
+  }
+
+  async getQuizAnswers(lectureId: string, studentId: string) {
+    return this.prisma.lectureQuizAnswer.findMany({
+      where: { lectureId, studentId },
+      include: {
+        question: {
+          select: {
+            id: true,
+            type: true,
+            content: true,
+            options: true,
+            correctIndex: true,
+            explanation: true,
+            answerGuide: true,
+          },
+        },
+      },
+    });
+  }
+
   async findStudentIdByUserId(userId: string): Promise<string | null> {
     const studentInfo = await this.prisma.studentInfo.findFirst({
       where: { userId },

--- a/apps/api/src/user/user-profile.controller.spec.ts
+++ b/apps/api/src/user/user-profile.controller.spec.ts
@@ -15,6 +15,11 @@ describe('UserProfileController', () => {
     createStudentSePayTopUpOrder: jest.fn(),
     getStudentSePayStaticQr: jest.fn(),
   };
+  const topicService = {
+    getLectureQuizzesForStudent: jest.fn(),
+    submitQuizAnswers: jest.fn(),
+    getQuizAnswers: jest.fn(),
+  };
 
   let controller: UserProfileController;
 
@@ -30,6 +35,7 @@ describe('UserProfileController', () => {
       studentService as never,
       {} as never,
       {} as never,
+      topicService as never,
     );
   });
 

--- a/apps/api/src/user/user-profile.controller.ts
+++ b/apps/api/src/user/user-profile.controller.ts
@@ -74,6 +74,8 @@ import {
 } from 'src/storage/supabase-storage';
 import { UserService } from './user.service';
 import { VerifiedEmailGuard } from 'src/auth/guards/verified-email.guard';
+import { TopicService } from 'src/topic/topic.service';
+import { LectureQuizAnswerDto } from 'src/dtos/topic.dto';
 
 @ApiTags('users')
 @Controller('users/me')
@@ -90,6 +92,7 @@ export class UserProfileController {
     private readonly studentService: StudentService,
     private readonly dashboardService: DashboardService,
     private readonly prisma: PrismaService,
+    private readonly topicService: TopicService,
   ) {}
 
   @Get('full')
@@ -1146,6 +1149,82 @@ export class UserProfileController {
       throw new NotFoundException('Topic not found');
     }
     return topic;
+  }
+
+  // ─── Student Lecture Quiz ───
+
+  @Get('student-classes/:classId/topics/:topicId/lectures/:lectureId/quizzes')
+  @ApiOperation({
+    summary: 'Get quiz questions for a lecture',
+    description:
+      'Returns linked quiz questions for a lecture. Students see questions without correctIndex.',
+  })
+  @ApiParam({ name: 'classId', description: 'Class ID' })
+  @ApiParam({ name: 'topicId', description: 'Topic ID' })
+  @ApiParam({ name: 'lectureId', description: 'Lecture ID' })
+  @ApiResponse({ status: 200, description: 'Quiz questions.' })
+  @ApiResponse({ status: 404, description: 'Lecture not found.' })
+  async getMyLectureQuizzes(
+    @CurrentUser() user: JwtPayload,
+    @Param('classId') classId: string,
+    @Param('topicId') topicId: string,
+    @Param('lectureId') lectureId: string,
+  ) {
+    const studentId = await this.userService.getLinkedStudentId(user.id);
+    await this.validateStudentClassAccess(classId, studentId);
+    return this.topicService.getLectureQuizzesForStudent(lectureId);
+  }
+
+  @Post(
+    'student-classes/:classId/topics/:topicId/lectures/:lectureId/quizzes/answers',
+  )
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Submit quiz answers for a lecture',
+    description: 'Upsert student answers. No Attempt created, no scoring.',
+  })
+  @ApiParam({ name: 'classId', description: 'Class ID' })
+  @ApiParam({ name: 'topicId', description: 'Topic ID' })
+  @ApiParam({ name: 'lectureId', description: 'Lecture ID' })
+  @ApiBody({ type: [LectureQuizAnswerDto] })
+  @ApiResponse({
+    status: 200,
+    description: 'Saved answers with correct answers for review.',
+  })
+  @ApiResponse({ status: 400, description: 'Invalid questions.' })
+  async submitQuizAnswers(
+    @CurrentUser() user: JwtPayload,
+    @Param('classId') classId: string,
+    @Param('topicId') topicId: string,
+    @Param('lectureId') lectureId: string,
+    @Body() answers: LectureQuizAnswerDto[],
+  ) {
+    const studentId = await this.userService.getLinkedStudentId(user.id);
+    await this.validateStudentClassAccess(classId, studentId);
+    return this.topicService.submitQuizAnswers(lectureId, studentId, answers);
+  }
+
+  @Get(
+    'student-classes/:classId/topics/:topicId/lectures/:lectureId/quizzes/answers',
+  )
+  @ApiOperation({
+    summary: 'Get my quiz answers for a lecture',
+    description:
+      'Returns student saved answers with correct answers for review.',
+  })
+  @ApiParam({ name: 'classId', description: 'Class ID' })
+  @ApiParam({ name: 'topicId', description: 'Topic ID' })
+  @ApiParam({ name: 'lectureId', description: 'Lecture ID' })
+  @ApiResponse({ status: 200, description: 'Student answers with questions.' })
+  async getMyQuizAnswers(
+    @CurrentUser() user: JwtPayload,
+    @Param('classId') classId: string,
+    @Param('topicId') topicId: string,
+    @Param('lectureId') lectureId: string,
+  ) {
+    const studentId = await this.userService.getLinkedStudentId(user.id);
+    await this.validateStudentClassAccess(classId, studentId);
+    return this.topicService.getQuizAnswers(lectureId, studentId);
   }
 
   private async validateStudentClassAccess(

--- a/apps/api/src/user/user.module.ts
+++ b/apps/api/src/user/user.module.ts
@@ -10,6 +10,7 @@ import { SessionModule } from 'src/session/session.module';
 import { StaffModule } from 'src/staff/staff.module';
 import { StudentModule } from 'src/student/student.module';
 import { SePayModule } from 'src/sepay/sepay.module';
+import { TopicModule } from 'src/topic/topic.module';
 import { UserController } from './user.controller';
 import { UserProfileController } from './user-profile.controller';
 import { UserService } from './user.service';
@@ -27,6 +28,7 @@ import { UserService } from './user.service';
     LessonModule,
     StudentModule,
     SePayModule,
+    TopicModule,
   ],
   controllers: [UserController, UserProfileController],
   providers: [UserService],

--- a/apps/web/app/student/classes/[id]/topics/[topicId]/page.tsx
+++ b/apps/web/app/student/classes/[id]/topics/[topicId]/page.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import Link from "next/link";
 import { useParams } from "next/navigation";
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   ChevronLeft,
   PlayCircle,
@@ -12,15 +12,24 @@ import {
   AlertCircle,
   FileText,
   List,
+  CheckCircle,
+  Send,
 } from "lucide-react";
-import { getMyClassDetail, getMyClassTopic } from "@/lib/apis/student-class.api";
+import { toast } from "sonner";
+import {
+  getMyClassDetail,
+  getMyClassTopic,
+  getMyLectureQuizzes,
+  getMyQuizAnswers,
+  submitMyQuizAnswers,
+} from "@/lib/apis/student-class.api";
 import { getLectures } from "@/lib/apis/class.api";
 import { Skeleton } from "@/components/ui/skeleton";
 import YouTubeEmbed from "@/components/ui/YouTubeEmbed";
 import { Card, CardContent } from "@/components/ui/card";
 import MathContent from "@/components/ui/MathContent";
 import { cn } from "@/lib/utils";
-import type { Lecture } from "@/dtos/topic.dto";
+import type { Lecture, LectureQuizQuestion, LectureQuizAnswer } from "@/dtos/topic.dto";
 
 function formatDate(date?: Date | string | null): string {
   if (!date) return "—";
@@ -263,6 +272,15 @@ export default function StudentTopicDetailPage() {
         </section>
       )}
 
+      {/* Quiz Section */}
+      {selectedLecture && (
+        <LectureQuizSection
+          classId={classId}
+          topicId={topicId}
+          lectureId={selectedLecture.id}
+        />
+      )}
+
       {/* Empty state */}
       {!hasLectures && (
         <div className="rounded-2xl border border-dashed border-border-default bg-bg-surface p-10 text-center text-sm text-text-muted">
@@ -274,6 +292,268 @@ export default function StudentTopicDetailPage() {
           Bài học này hiện chưa có nội dung văn bản hoặc video đính kèm.
         </div>
       )}
+    </div>
+  );
+}
+
+// ─── Lecture Quiz Section ─────────────────────────────────────
+
+function LectureQuizSection({
+  classId,
+  topicId,
+  lectureId,
+}: {
+  classId: string;
+  topicId: string;
+  lectureId: string;
+}) {
+  const queryClient = useQueryClient();
+  const [draftAnswers, setDraftAnswers] = useState<
+    Record<string, { choiceIndex?: number | null; essayAnswer?: string | null }>
+  >({});
+
+  const { data: quizzes = [], isLoading: quizzesLoading } = useQuery({
+    queryKey: ["student-lecture-quizzes", classId, topicId, lectureId],
+    queryFn: () => getMyLectureQuizzes(classId, topicId, lectureId),
+    staleTime: 60_000,
+  });
+
+  const { data: savedAnswers = [] } = useQuery({
+    queryKey: ["student-quiz-answers", classId, topicId, lectureId],
+    queryFn: () => getMyQuizAnswers(classId, topicId, lectureId),
+    staleTime: 60_000,
+  });
+
+  const submitMutation = useMutation({
+    mutationFn: () => {
+      const answers = quizzes.map((q) => ({
+        questionId: q.questionId,
+        choiceIndex: draftAnswers[q.questionId]?.choiceIndex ?? null,
+        essayAnswer: draftAnswers[q.questionId]?.essayAnswer ?? null,
+      }));
+      return submitMyQuizAnswers(classId, topicId, lectureId, answers);
+    },
+    onSuccess: () => {
+      toast.success("Đã nộp bài tập ôn nhẹ.");
+      queryClient.invalidateQueries({
+        queryKey: ["student-quiz-answers", classId, topicId, lectureId],
+      });
+    },
+    onError: () => {
+      toast.error("Không thể nộp bài. Vui lòng thử lại.");
+    },
+  });
+
+  if (quizzesLoading) {
+    return (
+      <Card className="rounded-2xl border border-border-default bg-bg-surface shadow-sm">
+        <CardContent className="p-5 sm:p-7">
+          <Skeleton className="h-5 w-48 mb-4" />
+          <Skeleton className="h-24 w-full mb-3" />
+          <Skeleton className="h-24 w-full" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (quizzes.length === 0) return null;
+
+  const hasSavedAnswers = savedAnswers.length > 0;
+
+  return (
+    <section aria-label="Bài tập ôn nhẹ" className="w-full">
+      <Card className="rounded-2xl border border-border-default bg-bg-surface shadow-sm">
+        <CardContent className="p-5 sm:p-7 md:p-8">
+          <div className="flex items-center gap-2 mb-4 pb-3 border-b border-border-subtle">
+            <CheckCircle className="size-4 text-primary" />
+            <h2 className="text-xs sm:text-sm font-bold uppercase tracking-wider text-text-secondary">
+              Bài tập ôn nhẹ — {quizzes.length} câu hỏi
+            </h2>
+          </div>
+
+          {hasSavedAnswers ? (
+            <QuizReview answers={savedAnswers} />
+          ) : (
+            <div className="space-y-4">
+              {quizzes.map((quiz, idx) => (
+                <QuizQuestionInput
+                  key={quiz.questionId}
+                  quiz={quiz}
+                  index={idx}
+                  value={draftAnswers[quiz.questionId]}
+                  onChange={(val) =>
+                    setDraftAnswers((prev) => ({
+                      ...prev,
+                      [quiz.questionId]: val,
+                    }))
+                  }
+                />
+              ))}
+              <div className="flex justify-end pt-2">
+                <button
+                  type="button"
+                  onClick={() => submitMutation.mutate()}
+                  disabled={submitMutation.isPending}
+                  className="inline-flex min-h-10 items-center justify-center gap-2 rounded-xl bg-primary px-5 py-2.5 text-sm font-medium text-text-inverse transition-colors hover:bg-primary-hover disabled:opacity-50"
+                >
+                  <Send className="size-4" />
+                  {submitMutation.isPending ? "Đang nộp..." : "Nộp bài"}
+                </button>
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </section>
+  );
+}
+
+// ─── Quiz Question Input ─────────────────────────────────────
+
+function QuizQuestionInput({
+  quiz,
+  index,
+  value,
+  onChange,
+}: {
+  quiz: LectureQuizQuestion;
+  index: number;
+  value?: { choiceIndex?: number | null; essayAnswer?: string | null };
+  onChange: (val: { choiceIndex?: number | null; essayAnswer?: string | null }) => void;
+}) {
+  const isSingleChoice = quiz.question.type === "single_choice";
+  const options: string[] = quiz.question.options ?? [];
+
+  return (
+    <div className="rounded-xl border border-border-default p-4">
+      <p className="text-sm font-medium text-text-primary mb-3">
+        <span className="text-primary mr-1">Câu {index + 1}.</span>
+        <MathContent content={quiz.question.content} className="inline" />
+      </p>
+
+      {isSingleChoice ? (
+        <div className="space-y-2">
+          {options.map((opt, i) => (
+            <label
+              key={i}
+              className={cn(
+                "flex cursor-pointer items-center gap-3 rounded-lg border px-3 py-2.5 text-sm transition-colors",
+                value?.choiceIndex === i
+                  ? "border-primary bg-primary/5 text-text-primary"
+                  : "border-border-default hover:bg-bg-secondary/50 text-text-secondary",
+              )}
+            >
+              <input
+                type="radio"
+                name={`quiz-${quiz.questionId}`}
+                checked={value?.choiceIndex === i}
+                onChange={() => onChange({ choiceIndex: i })}
+                className="accent-primary"
+              />
+              <span className="font-medium text-text-muted mr-1">
+                {String.fromCharCode(65 + i)}.
+              </span>
+              <MathContent content={opt} className="text-sm" />
+            </label>
+          ))}
+        </div>
+      ) : (
+        <textarea
+          value={value?.essayAnswer ?? ""}
+          onChange={(e) => onChange({ essayAnswer: e.target.value })}
+          placeholder="Nhập câu trả lời..."
+          rows={4}
+          className="w-full rounded-lg border border-border-default bg-bg-surface px-3 py-2.5 text-sm text-text-primary placeholder:text-text-muted focus:border-border-focus focus:outline-none focus-visible:ring-2 focus-visible:ring-border-focus"
+        />
+      )}
+    </div>
+  );
+}
+
+// ─── Quiz Review (after submission) ──────────────────────────
+
+function QuizReview({ answers }: { answers: LectureQuizAnswer[] }) {
+  return (
+    <div className="space-y-4">
+      <p className="text-xs text-text-muted mb-2">
+        Bạn đã nộp bài. Dưới đây là câu trả lời của bạn kèm đáp án đúng.
+      </p>
+      {answers.map((ans, idx) => {
+        const isCorrect =
+          ans.question.type === "single_choice" &&
+          ans.choiceIndex === ans.question.correctIndex;
+        const isEssay = ans.question.type === "essay";
+
+        return (
+          <div
+            key={ans.questionId}
+            className={cn(
+              "rounded-xl border p-4",
+              isCorrect
+                ? "border-success/30 bg-success/5"
+                : isEssay
+                  ? "border-border-default"
+                  : "border-error/30 bg-error/5",
+            )}
+          >
+            <p className="text-sm font-medium text-text-primary mb-2">
+              <span className="text-primary mr-1">Câu {idx + 1}.</span>
+              <MathContent content={ans.question.content} className="inline" />
+            </p>
+
+            {/* Student answer */}
+            <div className="mb-2">
+              <span className="text-xs font-semibold text-text-muted">Câu trả lời của bạn: </span>
+              {isEssay ? (
+                <p className="mt-1 text-sm text-text-secondary whitespace-pre-wrap">
+                  {ans.essayAnswer || "(chưa trả lời)"}
+                </p>
+              ) : (
+                <span className="text-sm text-text-secondary">
+                  {ans.choiceIndex !== null
+                    ? `${String.fromCharCode(65 + ans.choiceIndex)}. ${
+                        (ans.question.options ?? [])[ans.choiceIndex] ?? ""
+                      }`
+                    : "(chưa chọn)"}
+                </span>
+              )}
+            </div>
+
+            {/* Correct answer (for single_choice) */}
+            {!isEssay && ans.question.correctIndex !== null && (
+              <div className="mb-1">
+                <span className="text-xs font-semibold text-text-muted">Đáp án đúng: </span>
+                <span className="text-sm text-success font-medium">
+                  {String.fromCharCode(65 + ans.question.correctIndex)}.{" "}
+                  {(ans.question.options ?? [])[ans.question.correctIndex]}
+                </span>
+              </div>
+            )}
+
+            {/* Explanation */}
+            {ans.question.explanation && (
+              <div className="mt-2 rounded-lg bg-bg-secondary/50 p-2.5">
+                <span className="text-xs font-semibold text-text-muted">Giải thích: </span>
+                <MathContent
+                  content={ans.question.explanation}
+                  className="text-xs text-text-secondary"
+                />
+              </div>
+            )}
+
+            {/* Answer guide for essay */}
+            {isEssay && ans.question.answerGuide && (
+              <div className="mt-2 rounded-lg bg-bg-secondary/50 p-2.5">
+                <span className="text-xs font-semibold text-text-muted">Hướng dẫn: </span>
+                <MathContent
+                  content={ans.question.answerGuide}
+                  className="text-xs text-text-secondary"
+                />
+              </div>
+            )}
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/apps/web/components/admin/KnowledgeTreeCard.tsx
+++ b/apps/web/components/admin/KnowledgeTreeCard.tsx
@@ -18,9 +18,13 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 import { courseKeys } from "@/lib/query-keys";
 import * as classApi from "@/lib/apis/class.api";
+import * as questionApi from "@/lib/apis/question.api";
 import { runBackgroundSave } from "@/lib/mutation-feedback";
+import MathRichTextEditor from "@/components/ui/MathRichTextEditor";
+import MathContent from "@/components/ui/MathContent";
 import type {
   Chapter,
   Topic,
@@ -139,13 +143,11 @@ function DragHandle({ listeners }: { listeners?: Record<string, unknown> }) {
 
 function LectureItem({
   lecture,
-  topicId: parentTopicId,
   canEdit,
   onEdit,
   onDelete,
 }: {
   lecture: Lecture;
-  topicId: string;
   canEdit: boolean;
   onEdit: () => void;
   onDelete: () => void;
@@ -275,7 +277,6 @@ function TopicItem({
               <LectureItem
                 key={l.id}
                 lecture={l}
-                topicId={node.topic.id}
                 canEdit={canEdit}
                 onEdit={() => onEditLecture(l)}
                 onDelete={() => onDeleteLecture(l)}
@@ -523,6 +524,34 @@ export function KnowledgeTreeCard({
     lecture: Lecture;
   } | null>(null);
   const [editingLectureName, setEditingLectureName] = useState("");
+  const [editingLectureVideoUrl, setEditingLectureVideoUrl] = useState("");
+  const [editingLectureContent, setEditingLectureContent] = useState("");
+  const [editingLectureQuizIds, setEditingLectureQuizIds] = useState<string[]>([]);
+
+  // Quiz question bank for the course
+  const { data: courseQuestions = [] } = useQuery({
+    queryKey: ["course-questions", courseId],
+    queryFn: () => questionApi.getQuestions({}, 0, 200),
+    enabled: !!courseId && !!editingLecture,
+  });
+
+  // Currently linked quizzes for the editing lecture
+  const { data: linkedQuizzes = [] } = useQuery({
+    queryKey: ["lecture-quizzes", editingLecture?.lecture.id],
+    queryFn: () =>
+      editingLecture
+        ? classApi.getLectureQuizzes(editingLecture.topicId, editingLecture.lecture.id)
+        : Promise.resolve([]),
+    enabled: !!editingLecture,
+  });
+
+  // Initialize quiz IDs when linkedQuizzes loads (avoid setState in effect)
+  const quizIdsInitialized = editingLecture?.lecture.id ?? null;
+  const [initializedQuizLectureId, setInitializedQuizLectureId] = useState<string | null>(null);
+  if (quizIdsInitialized && linkedQuizzes.length > 0 && initializedQuizLectureId !== quizIdsInitialized) {
+    setInitializedQuizLectureId(quizIdsInitialized);
+    setEditingLectureQuizIds(linkedQuizzes.map((q) => q.questionId));
+  }
 
   const addLecture = (topicId: string) => {
     const title = newLectureName.trim();
@@ -538,19 +567,32 @@ export function KnowledgeTreeCard({
     });
   };
 
-  const saveLectureEdit = () => {
+  const saveLectureEdit = async () => {
     if (!editingLecture) return;
     const title = editingLectureName.trim();
     if (!title) return;
     const { topicId: tid, lecture } = editingLecture;
+    const videoUrl = editingLectureVideoUrl.trim() || null;
+    const content = editingLectureContent.trim() || null;
     setEditingLecture(null);
-    runBackgroundSave({
-      loadingMessage: "Đang cập nhật...",
-      successMessage: "Đã cập nhật.",
-      errorMessage: "Không thể cập nhật.",
-      action: () => classApi.updateLecture(tid, lecture.id, { title }),
-      onSuccess: invalidate,
-    });
+
+    // Update lecture fields
+    await classApi.updateLecture(tid, lecture.id, { title, videoUrl, content });
+
+    // Sync quiz links
+    const currentQuizIds = linkedQuizzes.map((q) => q.questionId);
+    const toAdd = editingLectureQuizIds.filter((id) => !currentQuizIds.includes(id));
+    const toRemove = currentQuizIds.filter((id) => !editingLectureQuizIds.includes(id));
+
+    if (toAdd.length) {
+      await classApi.linkQuizQuestions(tid, lecture.id, toAdd);
+    }
+    for (const qid of toRemove) {
+      await classApi.unlinkQuizQuestion(tid, lecture.id, qid);
+    }
+
+    toast.success("Đã cập nhật bài học.");
+    await invalidate();
   };
 
   const deleteLecture = (topicId: string, lecture: Lecture) => {
@@ -723,6 +765,9 @@ export function KnowledgeTreeCard({
                   onEditLecture={(topicId, lecture) => {
                     setEditingLecture({ topicId, lecture });
                     setEditingLectureName(lecture.title);
+                    setEditingLectureVideoUrl(lecture.videoUrl || "");
+                    setEditingLectureContent(lecture.content || "");
+                    setEditingLectureQuizIds([]);
                   }}
                   onDeleteLecture={deleteLecture}
                 />
@@ -937,22 +982,103 @@ export function KnowledgeTreeCard({
       {/* Inline edit lecture form */}
       {editingLecture ? (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30" onClick={() => setEditingLecture(null)}>
-          <div className="rounded-xl border border-border-default bg-bg-surface p-4 shadow-lg" onClick={(e) => e.stopPropagation()}>
+          <div
+            className="max-h-[90vh] w-full max-w-2xl overflow-y-auto rounded-xl border border-border-default bg-bg-surface p-4 shadow-lg sm:p-5"
+            onClick={(e) => e.stopPropagation()}
+          >
             <h3 className="text-sm font-semibold text-text-primary">Sửa bài học</h3>
-            <div className="mt-3 flex flex-col gap-2">
-              <input
-                autoFocus
-                value={editingLectureName}
-                onChange={(e) => setEditingLectureName(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") {
-                    e.preventDefault();
-                    saveLectureEdit();
-                  }
-                }}
-                className="rounded-md border border-border-default bg-bg-surface px-3 py-2 text-text-primary focus:border-border-focus focus:outline-none focus-visible:ring-2 focus-visible:ring-border-focus"
-              />
-              <div className="flex justify-end gap-2">
+            <div className="mt-3 flex flex-col gap-4">
+              {/* Title */}
+              <div>
+                <label className="mb-1 block text-xs font-medium text-text-muted">Tiêu đề</label>
+                <input
+                  autoFocus
+                  value={editingLectureName}
+                  onChange={(e) => setEditingLectureName(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      e.preventDefault();
+                      saveLectureEdit();
+                    }
+                  }}
+                  className="w-full rounded-md border border-border-default bg-bg-surface px-3 py-2 text-sm text-text-primary focus:border-border-focus focus:outline-none focus-visible:ring-2 focus-visible:ring-border-focus"
+                />
+              </div>
+
+              {/* Video URL */}
+              <div>
+                <label className="mb-1 block text-xs font-medium text-text-muted">Link video YouTube (tuỳ chọn)</label>
+                <input
+                  value={editingLectureVideoUrl}
+                  onChange={(e) => setEditingLectureVideoUrl(e.target.value)}
+                  placeholder="https://youtube.com/watch?v=..."
+                  className="w-full rounded-md border border-border-default bg-bg-surface px-3 py-2 text-sm text-text-primary placeholder:text-text-muted focus:border-border-focus focus:outline-none focus-visible:ring-2 focus-visible:ring-border-focus"
+                />
+              </div>
+
+              {/* Content (TipTap + Math) */}
+              <div>
+                <label className="mb-1 block text-xs font-medium text-text-muted">
+                  Nội dung lý thuyết (hỗ trợ LaTeX: $x^2$)
+                </label>
+                <MathRichTextEditor
+                  value={editingLectureContent}
+                  onChange={setEditingLectureContent}
+                  placeholder="Nhập nội dung bài học..."
+                  minHeight="min-h-[120px]"
+                />
+              </div>
+
+              {/* Quiz Question Picker */}
+              <div>
+                <label className="mb-1 block text-xs font-medium text-text-muted">
+                  Bài tập ôn nhẹ ({editingLectureQuizIds.length} câu đã chọn)
+                </label>
+                <p className="mb-2 text-xs text-text-muted">
+                  Chọn câu hỏi từ ngân hàng câu hỏi của khoá học.
+                </p>
+                {courseQuestions.length === 0 ? (
+                  <p className="text-xs text-text-muted italic">Chưa có câu hỏi nào trong ngân hàng.</p>
+                ) : (
+                  <div className="max-h-48 space-y-1.5 overflow-y-auto rounded-md border border-border-default p-2">
+                    {courseQuestions.map((q) => {
+                      const isSelected = editingLectureQuizIds.includes(q.id);
+                      return (
+                        <label
+                          key={q.id}
+                          className={`flex cursor-pointer items-start gap-2 rounded-md px-2 py-1.5 text-xs transition-colors ${
+                            isSelected ? "bg-primary/5" : "hover:bg-bg-secondary/50"
+                          }`}
+                        >
+                          <input
+                            type="checkbox"
+                            checked={isSelected}
+                            onChange={() => {
+                              setEditingLectureQuizIds((prev) =>
+                                isSelected
+                                  ? prev.filter((id) => id !== q.id)
+                                  : [...prev, q.id]
+                              );
+                            }}
+                            className="mt-0.5 accent-primary"
+                          />
+                          <span className="min-w-0 flex-1">
+                            <MathContent
+                              content={q.content.slice(0, 100)}
+                              className="text-xs"
+                            />
+                            <span className="ml-1 text-text-muted">
+                              ({q.type === "single_choice" ? "Trắc nghiệm" : "Tự luận"})
+                            </span>
+                          </span>
+                        </label>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+
+              <div className="flex justify-end gap-2 pt-1">
                 <button
                   type="button"
                   onClick={() => setEditingLecture(null)}

--- a/apps/web/components/admin/KnowledgeTreeCard.tsx
+++ b/apps/web/components/admin/KnowledgeTreeCard.tsx
@@ -18,7 +18,6 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { toast } from "sonner";
 import { courseKeys } from "@/lib/query-keys";
 import * as classApi from "@/lib/apis/class.api";
 import * as questionApi from "@/lib/apis/question.api";
@@ -567,32 +566,33 @@ export function KnowledgeTreeCard({
     });
   };
 
-  const saveLectureEdit = async () => {
+  const saveLectureEdit = () => {
     if (!editingLecture) return;
     const title = editingLectureName.trim();
     if (!title) return;
     const { topicId: tid, lecture } = editingLecture;
     const videoUrl = editingLectureVideoUrl.trim() || null;
     const content = editingLectureContent.trim() || null;
-    setEditingLecture(null);
-
-    // Update lecture fields
-    await classApi.updateLecture(tid, lecture.id, { title, videoUrl, content });
-
-    // Sync quiz links
     const currentQuizIds = linkedQuizzes.map((q) => q.questionId);
     const toAdd = editingLectureQuizIds.filter((id) => !currentQuizIds.includes(id));
     const toRemove = currentQuizIds.filter((id) => !editingLectureQuizIds.includes(id));
+    setEditingLecture(null);
 
-    if (toAdd.length) {
-      await classApi.linkQuizQuestions(tid, lecture.id, toAdd);
-    }
-    for (const qid of toRemove) {
-      await classApi.unlinkQuizQuestion(tid, lecture.id, qid);
-    }
-
-    toast.success("Đã cập nhật bài học.");
-    await invalidate();
+    runBackgroundSave({
+      loadingMessage: "Đang cập nhật bài học...",
+      successMessage: "Đã cập nhật bài học.",
+      errorMessage: "Không thể cập nhật bài học.",
+      action: async () => {
+        await classApi.updateLecture(tid, lecture.id, { title, videoUrl, content });
+        if (toAdd.length) {
+          await classApi.linkQuizQuestions(tid, lecture.id, toAdd);
+        }
+        for (const qid of toRemove) {
+          await classApi.unlinkQuizQuestion(tid, lecture.id, qid);
+        }
+      },
+      onSuccess: invalidate,
+    });
   };
 
   const deleteLecture = (topicId: string, lecture: Lecture) => {

--- a/apps/web/dtos/topic.dto.ts
+++ b/apps/web/dtos/topic.dto.ts
@@ -116,3 +116,47 @@ export interface UpdateQuestionLinkPayload {
   order?: number | null;
   points?: number | null;
 }
+
+// --- Lecture Quiz ---
+
+export interface LectureQuizQuestion {
+  id: string;
+  lectureId: string;
+  questionId: string;
+  order: number;
+  question: {
+    id: string;
+    type: string;
+    content: string;
+    options: string[] | null;
+    correctIndex: number | null;
+    explanation: string | null;
+    answerGuide: string | null;
+  };
+}
+
+export interface LectureQuizAnswer {
+  id: string;
+  lectureId: string;
+  questionId: string;
+  studentId: string;
+  choiceIndex: number | null;
+  essayAnswer: string | null;
+  createdAt: string;
+  updatedAt: string;
+  question: {
+    id: string;
+    type: string;
+    content: string;
+    options: string[] | null;
+    correctIndex: number | null;
+    explanation: string | null;
+    answerGuide: string | null;
+  };
+}
+
+export interface SubmitQuizAnswerPayload {
+  questionId: string;
+  choiceIndex?: number | null;
+  essayAnswer?: string | null;
+}

--- a/apps/web/lib/apis/class.api.ts
+++ b/apps/web/lib/apis/class.api.ts
@@ -671,6 +671,7 @@ import type {
   QuestionLinkSummary,
   CreateQuestionLinkPayload,
   UpdateQuestionLinkPayload,
+  LectureQuizQuestion,
 } from "@/dtos/topic.dto";
 
 // ── Chapters ──
@@ -905,4 +906,44 @@ export async function isPracticeTopicAssigned(topicId: string): Promise<boolean>
     `/topics/${safeId}/questions/is-assigned`,
   );
   return response.data.assigned;
+}
+
+// ── Lecture Quizzes (admin) ──
+
+export async function getLectureQuizzes(
+  topicId: string,
+  lectureId: string,
+): Promise<LectureQuizQuestion[]> {
+  const safeTopicId = encodeURIComponent(topicId);
+  const safeLectureId = encodeURIComponent(lectureId);
+  const response = await api.get<LectureQuizQuestion[]>(
+    `/topics/${safeTopicId}/lectures/${safeLectureId}/quizzes`,
+  );
+  return Array.isArray(response.data) ? response.data : [];
+}
+
+export async function linkQuizQuestions(
+  topicId: string,
+  lectureId: string,
+  questionIds: string[],
+): Promise<void> {
+  const safeTopicId = encodeURIComponent(topicId);
+  const safeLectureId = encodeURIComponent(lectureId);
+  await api.post(
+    `/topics/${safeTopicId}/lectures/${safeLectureId}/quizzes`,
+    { questionIds },
+  );
+}
+
+export async function unlinkQuizQuestion(
+  topicId: string,
+  lectureId: string,
+  questionId: string,
+): Promise<void> {
+  const safeTopicId = encodeURIComponent(topicId);
+  const safeLectureId = encodeURIComponent(lectureId);
+  const safeQuestionId = encodeURIComponent(questionId);
+  await api.delete(
+    `/topics/${safeTopicId}/lectures/${safeLectureId}/quizzes/${safeQuestionId}`,
+  );
 }

--- a/apps/web/lib/apis/student-class.api.ts
+++ b/apps/web/lib/apis/student-class.api.ts
@@ -4,6 +4,11 @@ import type {
   StudentSessionItem,
   StudentSurveyItem,
 } from "@/dtos/student-class.dto";
+import type {
+  LectureQuizQuestion,
+  LectureQuizAnswer,
+  SubmitQuizAnswerPayload,
+} from "@/dtos/topic.dto";
 
 export async function getMyClasses(): Promise<StudentClassItem[]> {
   const { data } = await api.get("/users/me/student-classes");
@@ -49,4 +54,41 @@ export async function getMyClassTopic(
     `/users/me/student-classes/${classId}/topics/${topicId}`,
   );
   return data;
+}
+
+// ─── Student Lecture Quiz ───
+
+export async function getMyLectureQuizzes(
+  classId: string,
+  topicId: string,
+  lectureId: string,
+): Promise<LectureQuizQuestion[]> {
+  const { data } = await api.get(
+    `/users/me/student-classes/${classId}/topics/${topicId}/lectures/${lectureId}/quizzes`,
+  );
+  return Array.isArray(data) ? data : [];
+}
+
+export async function submitMyQuizAnswers(
+  classId: string,
+  topicId: string,
+  lectureId: string,
+  answers: SubmitQuizAnswerPayload[],
+): Promise<LectureQuizAnswer[]> {
+  const { data } = await api.post(
+    `/users/me/student-classes/${classId}/topics/${topicId}/lectures/${lectureId}/quizzes/answers`,
+    answers,
+  );
+  return data;
+}
+
+export async function getMyQuizAnswers(
+  classId: string,
+  topicId: string,
+  lectureId: string,
+): Promise<LectureQuizAnswer[]> {
+  const { data } = await api.get(
+    `/users/me/student-classes/${classId}/topics/${topicId}/lectures/${lectureId}/quizzes/answers`,
+  );
+  return Array.isArray(data) ? data : [];
 }

--- a/docs/Database Schema.md
+++ b/docs/Database Schema.md
@@ -46,6 +46,8 @@ Tài liệu này được tổng hợp trực tiếp từ Prisma schema tại `a
 - `topics` (chuyên đề — nhóm nội dung cấp cao nhất trong khoá học hoặc lớp)
 - `chapters` (chủ đề — nhóm chuyên đề bên trong khoá học)
 - `lectures` (bài học — đơn vị nội dung bên trong chuyên đề lý thuyết)
+- `lecture_quizzes` (liên kết câu hỏi từ ngân hàng vào bài học ôn nhẹ)
+- `lecture_quiz_answers` (trả lời bài tập ôn nhẹ — không sinh Attempt, không tính điểm)
 
 ### Finance
 

--- a/docs/pages/student.md
+++ b/docs/pages/student.md
@@ -46,6 +46,9 @@
   - `GET /users/me/student-classes/:classId/surveys`
   - `GET /users/me/student-classes/:classId/topics`
   - `GET /users/me/student-classes/:classId/topics/:topicId`
+  - `GET /users/me/student-classes/:classId/topics/:topicId/lectures/:lectureId/quizzes`
+  - `POST /users/me/student-classes/:classId/topics/:topicId/lectures/:lectureId/quizzes/answers`
+  - `GET /users/me/student-classes/:classId/topics/:topicId/lectures/:lectureId/quizzes/answers`
   - `GET /users/me/student-wallet-history?limit=`
   - `GET /users/me/student-wallet-sepay-static-qr` (SePay QR tĩnh, nội dung `[SEPAY_TRANSFER_NOTE_PREFIX] UNIST-[0-9a-f]{10}`, không chứa số tiền/class id/tên lớp; response vẫn trả thêm `classIds` để tương thích)
   - `POST /users/me/student-wallet-sepay-topup-order` body `{ amount }` — legacy/dynamic order endpoint còn tồn tại để tương thích, UI chính không gọi.


### PR DESCRIPTION
## What

CRUD bài học (Lecture) trong chuyên đề lý thuyết với video nhúng + nội dung TipTap (có công thức toán) + bài tập ôn nhẹ từ ngân hàng câu hỏi của khoá.

## Why

Ticket #54 — Màn 06: Soạn bài học + bài tập ôn nhẹ. Bài học nằm trong Topic.kind === 'theory'.

## Changes

### Prisma Schema
- Added `LectureQuiz` model: links questions from course bank to lectures
- Added `LectureQuizAnswer` model: stores student answers (NO Attempt, NO scoring, NO grading queue)
- Added back-relations to `Lecture`, `Question`, `StudentInfo`

### Backend
- **LectureController**: 3 new endpoints
  - `POST /topics/:topicId/lectures/:lectureId/quizzes` — link questions
  - `DELETE /topics/:topicId/lectures/:lectureId/quizzes/:questionId` — unlink question
  - `GET /topics/:topicId/lectures/:lectureId/quizzes` — list linked questions
- **UserProfileController**: 3 new student-facing endpoints
  - `GET /users/me/student-classes/:classId/topics/:topicId/lectures/:lectureId/quizzes`
  - `POST .../quizzes/answers` — submit answers
  - `GET .../quizzes/answers` — get saved answers for review
- **TopicService**: quiz link/unlink/list + student answer submit/retrieve methods with ActionHistory audit

### Frontend Admin
- KnowledgeTreeCard lecture edit modal expanded:
  - Title input (existing)
  - Video URL input (new)
  - MathRichTextEditor for content (new)
  - Question picker with checkboxes from course bank (new)
- Quiz sync: link/unlink on save

### Frontend Student
- Topic detail page: quiz section below content for each lecture
- Quiz UI: radio groups for single_choice, textarea for essay
- Submit + review: shows student answers + correct answers + explanations

## Boundary (critical)
- **NO Attempt created** — lecture quiz answers are stored independently
- **NO scoring** — no points, no statistics impact
- **Essay answers do NOT enter grading queue**
- This is lightweight practice, different from practice Topics (exams)

## Verify
- `pnpm --filter api exec prisma validate` ✅
- `pnpm --filter api exec tsc --noEmit` ✅ (pre-existing image import errors only)
- `pnpm --filter api exec eslint <changed files>` ✅
- `pnpm --filter web exec tsc --noEmit` ✅ (pre-existing image import errors only)
- `pnpm --filter web exec eslint <changed files>` ✅

## Decisions
1. **Question picker scope**: course-level (not chapter-level) per CONTEXT.md
2. **Student quiz UX**: shows correct answers + explanations after first submission
3. **Lecture navigation**: uses existing tab selector pattern from PR #78