### PR TITLE
fix(security): lecture quiz GET thiếu enrollment check (#86)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -138,7 +138,7 @@
 - **Đội giáo án của một khoá**: nhóm nhân sự được gán riêng vào một Khoá học để soạn nội dung học thuật và ngân hàng câu hỏi của khoá đó. Trong nội bộ một khoá mọi thành viên có quyền ngang nhau, không có người soạn/người duyệt. Việc gán do admin, **Trưởng giáo án** (`lesson_plan_head`) hoặc **Trợ lí** (`assistant`) thực hiện.
 - **Trưởng giáo án** thấy và sửa được nội dung của mọi Khoá học không cần được gán; thành viên `lesson_plan` chỉ thấy khoá mình được gán.
 - **Dạy lớp** và **soạn giáo án khoá** là hai vai tách biệt: gia sư đang dạy lớp thuộc khoá X không tự động soạn được nội dung cấp khoá của X. Ngược lại, gia sư của lớp thuộc khoá X **được thêm câu hỏi mới vào Ngân hàng câu hỏi của khoá X** để tự ra đề cho lớp mình; câu hỏi đó nằm chung kho và đội giáo án vẫn sửa/xoá được.
-- **Quyền xem nội dung của học sinh**: thuộc một lớp của khoá X **không** cho học sinh thấy toàn bộ nội dung khoá X. Học sinh chỉ thấy những mục gia sư đã chủ động thêm vào danh sách nội dung của lớp.
+- **Quyền xem nội dung của học sinh**: thuộc một lớp của khoá X **không** cho học sinh thấy toàn bộ nội dung khoá X. Học sinh chỉ thấy những mục gia sư đã chủ động thêm vào danh sách nội dung của lớp. Câu hỏi ôn nhẹ của bài học cũng vậy: học sinh chỉ đọc qua route `student-classes` (kiểm tra enrollment), không qua `GET /topics/:topicId/lectures/:lectureId/quizzes`.
 
 ## Đăng nhập và thiết bị
 

--- a/apps/api/src/topic/topic.controller.spec.ts
+++ b/apps/api/src/topic/topic.controller.spec.ts
@@ -1,0 +1,60 @@
+import { StaffRole, UserRole } from 'generated/enums';
+import { ALLOW_STAFF_ROLES_ON_ADMIN_KEY } from 'src/auth/decorators/allow-staff-roles-on-admin.decorator';
+import { ROLES_KEY } from 'src/auth/decorators/roles.decorator';
+import { LectureController } from './topic.controller';
+import { TopicService } from './topic.service';
+
+function getHandler(methodName: string): (...args: never[]) => unknown {
+  const descriptor = Object.getOwnPropertyDescriptor(
+    LectureController.prototype,
+    methodName,
+  );
+  const methodTarget: unknown = descriptor?.value;
+  if (typeof methodTarget !== 'function') {
+    throw new Error(`LectureController.${methodName} not found`);
+  }
+  return methodTarget as (...args: never[]) => unknown;
+}
+
+describe('LectureController.getLectureQuizzes', () => {
+  it('restricts GET /topics/:topicId/lectures/:lectureId/quizzes to admin (not student)', () => {
+    const roles: unknown = Reflect.getMetadata(
+      ROLES_KEY,
+      getHandler('getLectureQuizzes'),
+    );
+    expect(roles).toEqual([UserRole.admin]);
+    expect(roles).not.toContain(UserRole.student);
+  });
+
+  it('keeps staff authoring roles on the admin lecture-quiz list route', () => {
+    const staffRoles: unknown = Reflect.getMetadata(
+      ALLOW_STAFF_ROLES_ON_ADMIN_KEY,
+      getHandler('getLectureQuizzes'),
+    );
+    expect(staffRoles).toEqual([
+      StaffRole.assistant,
+      StaffRole.teacher,
+      StaffRole.lesson_plan,
+      StaffRole.lesson_plan_head,
+    ]);
+  });
+
+  it('returns the admin quiz payload and never the student (no-correctIndex) variant', async () => {
+    const topicService = {
+      getLectureQuizzes: jest
+        .fn()
+        .mockResolvedValue([{ id: 'q1', correctIndex: 2 }]),
+      getLectureQuizzesForStudent: jest.fn(),
+    };
+    const controller = new LectureController(
+      topicService as unknown as TopicService,
+    );
+
+    await expect(
+      controller.getLectureQuizzes('topic-1', 'lecture-1'),
+    ).resolves.toEqual([{ id: 'q1', correctIndex: 2 }]);
+
+    expect(topicService.getLectureQuizzes).toHaveBeenCalledWith('lecture-1');
+    expect(topicService.getLectureQuizzesForStudent).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/topic/topic.controller.ts
+++ b/apps/api/src/topic/topic.controller.ts
@@ -576,26 +576,32 @@ export class LectureController {
   }
 
   @Get(':lectureId/quizzes')
-  @Roles(UserRole.admin, UserRole.student)
+  @Roles(UserRole.admin)
   @AllowStaffRolesOnAdminRoutes(
     StaffRole.assistant,
     StaffRole.teacher,
     StaffRole.lesson_plan,
     StaffRole.lesson_plan_head,
   )
-  @ApiOperation({ summary: 'Danh sách câu hỏi ôn nhẹ của bài học' })
+  @ApiOperation({
+    summary: 'Danh sách câu hỏi ôn nhẹ của bài học (admin/staff soạn nội dung)',
+    description:
+      'Học sinh không dùng route này. Student đọc quiz đã enrollment-check qua GET /users/me/student-classes/:classId/topics/:topicId/lectures/:lectureId/quizzes.',
+  })
   @ApiParam({ name: 'topicId', description: 'ID chuyên đề' })
   @ApiParam({ name: 'lectureId', description: 'ID bài học' })
-  @ApiResponse({ status: 200, description: 'Danh sách câu hỏi.' })
+  @ApiResponse({
+    status: 200,
+    description: 'Danh sách câu hỏi (kèm đáp án đúng).',
+  })
+  @ApiResponse({
+    status: 403,
+    description: 'Không đủ quyền — học sinh phải dùng route student-classes.',
+  })
   async getLectureQuizzes(
-    @CurrentUser() user: JwtPayload,
     @Param('topicId') topicId: string,
     @Param('lectureId') lectureId: string,
   ) {
-    // Students get questions without correctIndex
-    if (user.roleType === UserRole.student) {
-      return this.topicService.getLectureQuizzesForStudent(lectureId);
-    }
     return this.topicService.getLectureQuizzes(lectureId);
   }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,10 @@ Mọi thay đổi đáng kể của dự án được ghi lại tại file này.
 
 ## [Unreleased]
 
+### Security
+
+- **Ticket #86:** `GET /topics/:topicId/lectures/:lectureId/quizzes` chỉ còn `@Roles(admin)` (+ staff soạn nội dung). Học sinh phải dùng `GET /users/me/student-classes/:classId/topics/:topicId/lectures/:lectureId/quizzes` (có `validateStudentClassAccess`) để tránh IDOR nội dung câu hỏi ôn nhẹ theo `lectureId`.
+
 ### Added
 
 - **Thư viện đề thi — Ticket #56:**

--- a/docs/pages/student.md
+++ b/docs/pages/student.md
@@ -46,7 +46,7 @@
   - `GET /users/me/student-classes/:classId/surveys`
   - `GET /users/me/student-classes/:classId/topics`
   - `GET /users/me/student-classes/:classId/topics/:topicId`
-  - `GET /users/me/student-classes/:classId/topics/:topicId/lectures/:lectureId/quizzes`
+  - `GET /users/me/student-classes/:classId/topics/:topicId/lectures/:lectureId/quizzes` (enrollment-checked via `validateStudentClassAccess`; đây là route quiz duy nhất cho học sinh — `GET /topics/:topicId/lectures/:lectureId/quizzes` là admin/staff soạn nội dung, không mở `UserRole.student`)
   - `POST /users/me/student-classes/:classId/topics/:topicId/lectures/:lectureId/quizzes/answers`
   - `GET /users/me/student-classes/:classId/topics/:topicId/lectures/:lectureId/quizzes/answers`
   - `GET /users/me/student-wallet-history?limit=`


### PR DESCRIPTION
## Summary
- `GET /topics/:topicId/lectures/:lectureId/quizzes` no longer includes `UserRole.student`. FE student already uses `GET /users/me/student-classes/:classId/topics/:topicId/lectures/:lectureId/quizzes` (`validateStudentClassAccess`); admin/staff still load quizzes via `class.api.ts` / `KnowledgeTreeCard`.
- Removes the unguarded student branch that returned question text without class enrollment, closing the IDOR surface called out in review of PR #83.
- Adds `LectureController.getLectureQuizzes` metadata + delegation tests; docs (`CHANGELOG`, `student.md`, `CONTEXT.md`) match the admin-only contract.

Closes #86

## Test plan
- [x] `pnpm exec tsc --noEmit` in `apps/api`
- [x] `pnpm exec eslint` on `topic.controller.ts` + spec
- [x] `pnpm exec jest src/topic/topic.controller.spec.ts`
- [ ] Confirm a student session cannot call `GET /topics/:topicId/lectures/:lectureId/quizzes` (403)
- [ ] Confirm student class topic page still loads quizzes via `/users/me/student-classes/.../quizzes`
- [ ] Confirm admin/staff lecture quiz editor still lists questions


Made with [Cursor](https://cursor.com)