### PR TITLE
fix(session): bỏ bắt buộc recordingUrl khi tạo/sửa buổi học

### DIFF
--- a/apps/api/src/session/session-create.service.spec.ts
+++ b/apps/api/src/session/session-create.service.spec.ts
@@ -239,9 +239,9 @@ describe('SessionCreateService', () => {
     expect(createSessionSpy.mock.calls[0][0].allowanceAmount).toBeUndefined();
   });
 
-  it('throws BadRequestException when creating session with >= 2 students without recordingUrl', async () => {
+  it('allows creating session with >= 2 students without recordingUrl (recording is optional)', async () => {
     mockPrisma.$transaction.mockImplementation(async (callback: never) => {
-      const tx = {
+      const tx = baseTx({
         classTeacher: {
           findUnique: jest.fn().mockResolvedValue({
             id: 'ct-1',
@@ -256,6 +256,7 @@ describe('SessionCreateService', () => {
           }),
         },
         customerCareService: { findMany: jest.fn().mockResolvedValue([]) },
+        staffInfo: { findMany: jest.fn().mockResolvedValue([]) },
         studentClass: {
           findMany: jest.fn().mockResolvedValue([
             {
@@ -272,37 +273,53 @@ describe('SessionCreateService', () => {
             },
           ]),
         },
-      };
+        session: {
+          create: jest.fn().mockResolvedValue({
+            id: 'session-no-recording',
+            attendance: [
+              { id: 'att-1', studentId: 'student-1' },
+              { id: 'att-2', studentId: 'student-2' },
+            ],
+          }),
+        },
+      });
       return (callback as (tx: unknown) => Promise<unknown>)(tx);
     });
     scheduleRulesService.assertSessionMatchesDeclaredSchedule.mockResolvedValue(
-      null,
+      { makeupEventId: null },
+    );
+    validationService.parseSessionDate.mockReturnValue(new Date('2026-03-20'));
+    validationService.normalizeCoefficient.mockReturnValue(1);
+    validationService.isTuitionChargeableStatus.mockReturnValue(true);
+    validationService.resolveChargeableAttendanceTuitionFee.mockReturnValue(
+      100000,
+    );
+    validationService.resolveDefaultStudentTuitionPerSession.mockReturnValue(
+      100000,
     );
 
-    await expect(
-      service.createSession({
-        classId: 'class-1',
-        teacherId: 'teacher-1',
-        date: '2026-03-20',
-        lessonContent: '<p>Nội dung</p>',
-        homework: '<p>BTVN</p>',
-        tutorial: '<p>Tutorial</p>',
-        attendance: [
-          {
-            studentId: 'student-1',
-            status: AttendanceStatus.present,
-            notes: null,
-          },
-          {
-            studentId: 'student-2',
-            status: AttendanceStatus.present,
-            notes: null,
-          },
-        ],
-      }),
-    ).rejects.toThrow(
-      'Link video YouTube (recording) là bắt buộc đối với lớp có từ 2 học sinh trở lên.',
-    );
+    const result = await service.createSession({
+      classId: 'class-1',
+      teacherId: 'teacher-1',
+      date: '2026-03-20',
+      lessonContent: '<p>Nội dung</p>',
+      homework: '<p>BTVN</p>',
+      tutorial: '<p>Tutorial</p>',
+      attendance: [
+        {
+          studentId: 'student-1',
+          status: AttendanceStatus.present,
+          notes: null,
+        },
+        {
+          studentId: 'student-2',
+          status: AttendanceStatus.present,
+          notes: null,
+        },
+      ],
+    });
+
+    expect(result.id).toBe('session-no-recording');
   });
 
   it('noAttendance class auto-generates present for all active students and snapshots snapshotNoAttendance', async () => {

--- a/apps/api/src/session/session-create.service.ts
+++ b/apps/api/src/session/session-create.service.ts
@@ -256,15 +256,6 @@ export class SessionCreateService {
             );
           }
 
-          if (uniqueAttendanceStudentIds.size >= 2) {
-            const recording = data.recordingUrl?.trim();
-            if (!recording) {
-              throw new BadRequestException(
-                'Link video YouTube (recording) là bắt buộc đối với lớp có từ 2 học sinh trở lên.',
-              );
-            }
-          }
-
           const coefficient =
             this.sessionValidationService.normalizeCoefficient(
               data.coefficient,

--- a/apps/api/src/session/session-update.service.spec.ts
+++ b/apps/api/src/session/session-update.service.spec.ts
@@ -32,6 +32,15 @@ describe('SessionUpdateService', () => {
     staffTaxDeductionOverride: {
       findFirst: jest.fn(),
     },
+    studentInfo: {
+      findMany: jest.fn(),
+    },
+    attendance: {
+      findMany: jest.fn(),
+    },
+    staffInfo: {
+      findMany: jest.fn(),
+    },
   };
 
   const accessService = {
@@ -75,6 +84,9 @@ describe('SessionUpdateService', () => {
     mockPrisma.classTeacher.findUnique.mockResolvedValue(null);
     mockPrisma.roleTaxDeductionRate.findFirst.mockResolvedValue(null);
     mockPrisma.staffTaxDeductionOverride.findFirst.mockResolvedValue(null);
+    mockPrisma.studentInfo.findMany.mockResolvedValue([]);
+    mockPrisma.attendance.findMany.mockResolvedValue([]);
+    mockPrisma.staffInfo.findMany.mockResolvedValue([]);
     service = new SessionUpdateService(
       mockPrisma as never,
       accessService as never,
@@ -393,28 +405,34 @@ describe('SessionUpdateService', () => {
     );
   });
 
-  it('throws BadRequestException when updating session with >= 2 students without recordingUrl', async () => {
-    mockPrisma.session.findUnique.mockResolvedValueOnce({
+  it('allows updating session with >= 2 students without recordingUrl (recording is optional)', async () => {
+    mockPrisma.session.findUnique
+      .mockResolvedValueOnce({
+        id: 'session-1',
+        classId: 'class-1',
+        teacherId: 'teacher-1',
+        date: new Date('2026-03-15T00:00:00.000Z'),
+        teacherPaymentStatus: SessionPaymentStatus.unpaid,
+        recordingUrl: null,
+        class: { name: 'Toán 10A' },
+        attendance: [
+          { id: 'att-1', studentId: 'student-1' },
+          { id: 'att-2', studentId: 'student-2' },
+        ],
+      })
+      .mockResolvedValueOnce({
+        id: 'session-1',
+        attendance: [
+          { id: 'att-1', studentId: 'student-1' },
+          { id: 'att-2', studentId: 'student-2' },
+        ],
+      });
+
+    await service.updateSession({
       id: 'session-1',
-      classId: 'class-1',
-      teacherId: 'teacher-1',
-      date: new Date('2026-03-15T00:00:00.000Z'),
-      teacherPaymentStatus: SessionPaymentStatus.unpaid,
-      recordingUrl: null,
-      class: { name: 'Toán 10A' },
-      attendance: [
-        { id: 'att-1', studentId: 'student-1' },
-        { id: 'att-2', studentId: 'student-2' },
-      ],
+      recordingUrl: '',
     });
 
-    await expect(
-      service.updateSession({
-        id: 'session-1',
-        recordingUrl: '',
-      }),
-    ).rejects.toThrow(
-      'Link video YouTube (recording) là bắt buộc đối với lớp có từ 2 học sinh trở lên.',
-    );
+    expect(mockPrisma.session.update).toHaveBeenCalled();
   });
 });

--- a/apps/api/src/session/session-update.service.spec.ts
+++ b/apps/api/src/session/session-update.service.spec.ts
@@ -433,6 +433,10 @@ describe('SessionUpdateService', () => {
       recordingUrl: '',
     });
 
-    expect(mockPrisma.session.update).toHaveBeenCalled();
+    const updateArgs = mockPrisma.session.update.mock.calls[0][0];
+    expect(updateArgs).toMatchObject({
+      where: { id: 'session-1' },
+      data: { recordingUrl: null },
+    });
   });
 });

--- a/apps/api/src/session/session-update.service.ts
+++ b/apps/api/src/session/session-update.service.ts
@@ -929,22 +929,6 @@ export class SessionUpdateService {
             )
           : undefined;
 
-        const targetStudentCount =
-          data.attendance !== undefined
-            ? data.attendance.length
-            : existingSession.attendance.length;
-        if (targetStudentCount >= 2) {
-          const effectiveRecordingUrl =
-            data.recordingUrl !== undefined
-              ? (data.recordingUrl?.trim() ?? '')
-              : (existingSession.recordingUrl?.trim() ?? '');
-          if (!effectiveRecordingUrl) {
-            throw new BadRequestException(
-              'Link video YouTube (recording) là bắt buộc đối với lớp có từ 2 học sinh trở lên.',
-            );
-          }
-        }
-
         const balanceStudentIds = Array.from(
           new Set([
             ...existingSession.attendance.map(

--- a/apps/web/components/admin/class/AddSessionPopup.tsx
+++ b/apps/web/components/admin/class/AddSessionPopup.tsx
@@ -274,7 +274,6 @@ export default function AddSessionPopup({
   const [homeworkError, setHomeworkError] = useState("");
   const [tutorialError, setTutorialError] = useState("");
   const [recordingUrlError, setRecordingUrlError] = useState("");
-  const isRecordingRequired = students.length >= 2;
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isTrialLesson, setIsTrialLesson] = useState(false);
   const [teacherPaymentStatus, setTeacherPaymentStatus] = useState<string>("unpaid");
@@ -603,26 +602,7 @@ export default function AddSessionPopup({
       return;
     }
 
-    if (isRecordingRequired) {
-      const trimmedRecording = recordingUrl.trim();
-      if (!trimmedRecording) {
-        setRecordingUrlError(
-          "Vui lòng nhập link video YouTube (recording) cho lớp có từ 2 học sinh trở lên.",
-        );
-        toast.error(
-          "Vui lòng nhập link video YouTube (recording) cho lớp có từ 2 học sinh trở lên.",
-        );
-        return;
-      }
-      if (!extractYouTubeVideoId(trimmedRecording)) {
-        setRecordingUrlError("Link video YouTube không hợp lệ.");
-        toast.error("Link video YouTube không hợp lệ.");
-        return;
-      }
-    } else if (
-      recordingUrl.trim() &&
-      !extractYouTubeVideoId(recordingUrl.trim())
-    ) {
+    if (recordingUrl.trim() && !extractYouTubeVideoId(recordingUrl.trim())) {
       setRecordingUrlError("Link video YouTube không hợp lệ.");
       toast.error("Link video YouTube không hợp lệ.");
       return;
@@ -993,12 +973,9 @@ export default function AddSessionPopup({
                   <div className="flex flex-col gap-1.5 text-sm font-medium text-text-primary">
                     <label htmlFor="add-session-recording-url" className="flex items-center gap-1.5">
                       <span>Link video YouTube (recording)</span>
-                      {isRecordingRequired ? <RequiredMark /> : null}
-                      {isRecordingRequired ? (
-                        <span className="text-xs font-normal text-text-muted">
-                          (Bắt buộc đối với lớp từ 2 học sinh)
-                        </span>
-                      ) : null}
+                      <span className="text-xs font-normal text-text-muted">
+                        (Không bắt buộc)
+                      </span>
                     </label>
                     <input
                       id="add-session-recording-url"

--- a/apps/web/components/admin/session/SessionHistoryTable.tsx
+++ b/apps/web/components/admin/session/SessionHistoryTable.tsx
@@ -1351,22 +1351,7 @@ export default function SessionHistoryTable({
       }
     }
 
-    const sessionStudentCount =
-      editingSession.attendance?.length ?? attendanceItems.length;
-    const isRecordingRequired = sessionStudentCount >= 2;
-    if (isRecordingRequired) {
-      const trimmedRecording = editRecordingUrl.trim();
-      if (!trimmedRecording) {
-        toast.error(
-          "Vui lòng nhập link video YouTube (recording) cho lớp có từ 2 học sinh trở lên.",
-        );
-        return;
-      }
-      if (!extractYouTubeVideoId(trimmedRecording)) {
-        toast.error("Link video YouTube không hợp lệ.");
-        return;
-      }
-    } else if (
+    if (
       editRecordingUrl.trim() &&
       !extractYouTubeVideoId(editRecordingUrl.trim())
     ) {
@@ -3087,14 +3072,9 @@ export default function SessionHistoryTable({
                     <div className="flex flex-col gap-1.5 text-sm font-medium text-text-primary">
                       <label htmlFor="edit-session-recording-url" className="flex items-center gap-1.5">
                         <span>Link video YouTube (recording)</span>
-                        {(editingSession?.attendance?.length ?? attendanceItems.length) >= 2 ? (
-                          <RequiredMark />
-                        ) : null}
-                        {(editingSession?.attendance?.length ?? attendanceItems.length) >= 2 ? (
-                          <span className="text-xs font-normal text-text-muted">
-                            (Bắt buộc đối với lớp từ 2 học sinh)
-                          </span>
-                        ) : null}
+                        <span className="text-xs font-normal text-text-muted">
+                          (Không bắt buộc)
+                        </span>
                       </label>
                       <input
                         id="edit-session-recording-url"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -55,6 +55,10 @@ Mọi thay đổi đáng kể của dự án được ghi lại tại file này.
 
 ### Changed
 
+- **Hotfix — Link video YouTube (recording) không còn bắt buộc khi tạo/sửa buổi học:**
+  - **Backend:** `SessionCreateService` và `SessionUpdateService` bỏ validation bắt buộc `recordingUrl` khi lớp có $\ge 2$ học sinh (rule thêm ở mục "Bắt buộc nhập Link video YouTube..." bên dưới, nay đảo ngược). `recordingUrl` luôn optional cho mọi lớp/mọi actor; nếu có nhập, format YouTube vẫn chưa được validate ở backend (chỉ validate ở frontend, không đổi trong hotfix này).
+  - **Frontend:** `AddSessionPopup` (tạo buổi học) và `SessionHistoryTable` (sửa buổi học) bỏ dấu bắt buộc và chặn submit khi thiếu `recordingUrl`; vẫn giữ validate định dạng YouTube (`extractYouTubeVideoId`) khi người dùng có nhập link.
+
 - **Panel Thêm chuyên đề — default tab + cây (#87):** Mở **Thêm chuyên đề** mặc định tab **Thêm từ khoá** khi khoá học của lớp còn chuyên đề; fallback **Tạo mới cho lớp** nếu không có topic để chọn. `CourseTopicPicker` đổi từ list phẳng nhóm `chapterTitle` sang cây Chủ đề → Chuyên đề có expand/collapse (mobile-first). Không đổi API/schema.
 
 - **Buổi học không điểm danh (`noAttendance`) — backend guard khi cập nhật session:**


### PR DESCRIPTION
## Vấn đề

Rule nghiệp vụ cũ (SessionCreateService/SessionUpdateService) từ chối tạo/cập nhật buổi học nếu lớp có >= 2 học sinh mà thiếu `recordingUrl`. Rule này không còn phù hợp — gia sư không nên bị bắt buộc phải có link video mới lưu được buổi học.

## Thay đổi

- **Backend:** xoá check bắt buộc `recordingUrl` (>= 2 học sinh) trong `session-create.service.ts` và `session-update.service.ts`. `recordingUrl` optional cho mọi actor, mọi lớp. Không đổi schema (đã nullable từ trước).
- **Frontend:** `AddSessionPopup.tsx` (tạo buổi học) và `SessionHistoryTable.tsx` (sửa buổi học) bỏ `RequiredMark`/label "bắt buộc" và bỏ chặn submit khi thiếu recordingUrl; vẫn giữ validate định dạng YouTube (`extractYouTubeVideoId`) khi có nhập giá trị.
- **Tests:** thay 2 test khẳng định throw `BadRequestException` khi thiếu recordingUrl bằng 2 test khẳng định tạo/sửa **thành công** khi thiếu recordingUrl (>= 2 học sinh).
- **Docs:** cập nhật `docs/CHANGELOG.md` (mục Changed) ghi nhận rule đảo ngược.

## Ngoài phạm vi (đã thống nhất, không làm trong hotfix này)

- Không thêm validate định dạng YouTube ở backend (hiện chỉ có ở frontend) — giữ nguyên hiện trạng, không mở rộng phạm vi hotfix.
- Không viết ADR (rule dễ đảo ngược lại, không có trade-off đặc biệt).

## Verify

- `pnpm --filter api exec tsc --noEmit` — pass (0 lỗi)
- `pnpm --filter api exec eslint src/session/session-create.service.ts src/session/session-update.service.ts src/session/session-create.service.spec.ts src/session/session-update.service.spec.ts` — pass (0 lỗi mới; 5 lỗi pre-existing không liên quan đã đối chiếu baseline)
- `pnpm --filter api exec jest src/session` — 58/58 pass
- `pnpm --filter api exec prisma validate` — schema hợp lệ
- `pnpm --filter web exec tsc --noEmit` — không có lỗi mới (2 lỗi cache `.next` cũ không liên quan)
- `pnpm --filter web exec eslint components/admin/class/AddSessionPopup.tsx components/admin/session/SessionHistoryTable.tsx` — 0 lỗi mới; 10 lỗi pre-existing đối chiếu baseline khớp
- `git merge-base origin/dev HEAD` khớp tip `origin/dev` (`c8a5ad9`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SqxEDMRfCMXd6nDBaafiPM