### PR TITLE
Revert "fix(session): bỏ bắt buộc recordingUrl khi tạo/sửa buổi học (#92)"

### DIFF
--- a/apps/api/src/session/session-create.service.spec.ts
+++ b/apps/api/src/session/session-create.service.spec.ts
@@ -239,9 +239,9 @@ describe('SessionCreateService', () => {
     expect(createSessionSpy.mock.calls[0][0].allowanceAmount).toBeUndefined();
   });
 
-  it('allows creating session with >= 2 students without recordingUrl (recording is optional)', async () => {
+  it('throws BadRequestException when creating session with >= 2 students without recordingUrl', async () => {
     mockPrisma.$transaction.mockImplementation(async (callback: never) => {
-      const tx = baseTx({
+      const tx = {
         classTeacher: {
           findUnique: jest.fn().mockResolvedValue({
             id: 'ct-1',
@@ -256,7 +256,6 @@ describe('SessionCreateService', () => {
           }),
         },
         customerCareService: { findMany: jest.fn().mockResolvedValue([]) },
-        staffInfo: { findMany: jest.fn().mockResolvedValue([]) },
         studentClass: {
           findMany: jest.fn().mockResolvedValue([
             {
@@ -273,53 +272,37 @@ describe('SessionCreateService', () => {
             },
           ]),
         },
-        session: {
-          create: jest.fn().mockResolvedValue({
-            id: 'session-no-recording',
-            attendance: [
-              { id: 'att-1', studentId: 'student-1' },
-              { id: 'att-2', studentId: 'student-2' },
-            ],
-          }),
-        },
-      });
+      };
       return (callback as (tx: unknown) => Promise<unknown>)(tx);
     });
     scheduleRulesService.assertSessionMatchesDeclaredSchedule.mockResolvedValue(
-      { makeupEventId: null },
-    );
-    validationService.parseSessionDate.mockReturnValue(new Date('2026-03-20'));
-    validationService.normalizeCoefficient.mockReturnValue(1);
-    validationService.isTuitionChargeableStatus.mockReturnValue(true);
-    validationService.resolveChargeableAttendanceTuitionFee.mockReturnValue(
-      100000,
-    );
-    validationService.resolveDefaultStudentTuitionPerSession.mockReturnValue(
-      100000,
+      null,
     );
 
-    const result = await service.createSession({
-      classId: 'class-1',
-      teacherId: 'teacher-1',
-      date: '2026-03-20',
-      lessonContent: '<p>Nội dung</p>',
-      homework: '<p>BTVN</p>',
-      tutorial: '<p>Tutorial</p>',
-      attendance: [
-        {
-          studentId: 'student-1',
-          status: AttendanceStatus.present,
-          notes: null,
-        },
-        {
-          studentId: 'student-2',
-          status: AttendanceStatus.present,
-          notes: null,
-        },
-      ],
-    });
-
-    expect(result.id).toBe('session-no-recording');
+    await expect(
+      service.createSession({
+        classId: 'class-1',
+        teacherId: 'teacher-1',
+        date: '2026-03-20',
+        lessonContent: '<p>Nội dung</p>',
+        homework: '<p>BTVN</p>',
+        tutorial: '<p>Tutorial</p>',
+        attendance: [
+          {
+            studentId: 'student-1',
+            status: AttendanceStatus.present,
+            notes: null,
+          },
+          {
+            studentId: 'student-2',
+            status: AttendanceStatus.present,
+            notes: null,
+          },
+        ],
+      }),
+    ).rejects.toThrow(
+      'Link video YouTube (recording) là bắt buộc đối với lớp có từ 2 học sinh trở lên.',
+    );
   });
 
   it('noAttendance class auto-generates present for all active students and snapshots snapshotNoAttendance', async () => {

--- a/apps/api/src/session/session-create.service.ts
+++ b/apps/api/src/session/session-create.service.ts
@@ -256,6 +256,15 @@ export class SessionCreateService {
             );
           }
 
+          if (uniqueAttendanceStudentIds.size >= 2) {
+            const recording = data.recordingUrl?.trim();
+            if (!recording) {
+              throw new BadRequestException(
+                'Link video YouTube (recording) là bắt buộc đối với lớp có từ 2 học sinh trở lên.',
+              );
+            }
+          }
+
           const coefficient =
             this.sessionValidationService.normalizeCoefficient(
               data.coefficient,

--- a/apps/api/src/session/session-update.service.spec.ts
+++ b/apps/api/src/session/session-update.service.spec.ts
@@ -32,15 +32,6 @@ describe('SessionUpdateService', () => {
     staffTaxDeductionOverride: {
       findFirst: jest.fn(),
     },
-    studentInfo: {
-      findMany: jest.fn(),
-    },
-    attendance: {
-      findMany: jest.fn(),
-    },
-    staffInfo: {
-      findMany: jest.fn(),
-    },
   };
 
   const accessService = {
@@ -84,9 +75,6 @@ describe('SessionUpdateService', () => {
     mockPrisma.classTeacher.findUnique.mockResolvedValue(null);
     mockPrisma.roleTaxDeductionRate.findFirst.mockResolvedValue(null);
     mockPrisma.staffTaxDeductionOverride.findFirst.mockResolvedValue(null);
-    mockPrisma.studentInfo.findMany.mockResolvedValue([]);
-    mockPrisma.attendance.findMany.mockResolvedValue([]);
-    mockPrisma.staffInfo.findMany.mockResolvedValue([]);
     service = new SessionUpdateService(
       mockPrisma as never,
       accessService as never,
@@ -405,38 +393,28 @@ describe('SessionUpdateService', () => {
     );
   });
 
-  it('allows updating session with >= 2 students without recordingUrl (recording is optional)', async () => {
-    mockPrisma.session.findUnique
-      .mockResolvedValueOnce({
-        id: 'session-1',
-        classId: 'class-1',
-        teacherId: 'teacher-1',
-        date: new Date('2026-03-15T00:00:00.000Z'),
-        teacherPaymentStatus: SessionPaymentStatus.unpaid,
-        recordingUrl: null,
-        class: { name: 'Toán 10A' },
-        attendance: [
-          { id: 'att-1', studentId: 'student-1' },
-          { id: 'att-2', studentId: 'student-2' },
-        ],
-      })
-      .mockResolvedValueOnce({
-        id: 'session-1',
-        attendance: [
-          { id: 'att-1', studentId: 'student-1' },
-          { id: 'att-2', studentId: 'student-2' },
-        ],
-      });
-
-    await service.updateSession({
+  it('throws BadRequestException when updating session with >= 2 students without recordingUrl', async () => {
+    mockPrisma.session.findUnique.mockResolvedValueOnce({
       id: 'session-1',
-      recordingUrl: '',
+      classId: 'class-1',
+      teacherId: 'teacher-1',
+      date: new Date('2026-03-15T00:00:00.000Z'),
+      teacherPaymentStatus: SessionPaymentStatus.unpaid,
+      recordingUrl: null,
+      class: { name: 'Toán 10A' },
+      attendance: [
+        { id: 'att-1', studentId: 'student-1' },
+        { id: 'att-2', studentId: 'student-2' },
+      ],
     });
 
-    const updateArgs = mockPrisma.session.update.mock.calls[0][0];
-    expect(updateArgs).toMatchObject({
-      where: { id: 'session-1' },
-      data: { recordingUrl: null },
-    });
+    await expect(
+      service.updateSession({
+        id: 'session-1',
+        recordingUrl: '',
+      }),
+    ).rejects.toThrow(
+      'Link video YouTube (recording) là bắt buộc đối với lớp có từ 2 học sinh trở lên.',
+    );
   });
 });

--- a/apps/api/src/session/session-update.service.ts
+++ b/apps/api/src/session/session-update.service.ts
@@ -929,6 +929,22 @@ export class SessionUpdateService {
             )
           : undefined;
 
+        const targetStudentCount =
+          data.attendance !== undefined
+            ? data.attendance.length
+            : existingSession.attendance.length;
+        if (targetStudentCount >= 2) {
+          const effectiveRecordingUrl =
+            data.recordingUrl !== undefined
+              ? (data.recordingUrl?.trim() ?? '')
+              : (existingSession.recordingUrl?.trim() ?? '');
+          if (!effectiveRecordingUrl) {
+            throw new BadRequestException(
+              'Link video YouTube (recording) là bắt buộc đối với lớp có từ 2 học sinh trở lên.',
+            );
+          }
+        }
+
         const balanceStudentIds = Array.from(
           new Set([
             ...existingSession.attendance.map(

--- a/apps/web/components/admin/class/AddSessionPopup.tsx
+++ b/apps/web/components/admin/class/AddSessionPopup.tsx
@@ -274,6 +274,7 @@ export default function AddSessionPopup({
   const [homeworkError, setHomeworkError] = useState("");
   const [tutorialError, setTutorialError] = useState("");
   const [recordingUrlError, setRecordingUrlError] = useState("");
+  const isRecordingRequired = students.length >= 2;
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isTrialLesson, setIsTrialLesson] = useState(false);
   const [teacherPaymentStatus, setTeacherPaymentStatus] = useState<string>("unpaid");
@@ -602,7 +603,26 @@ export default function AddSessionPopup({
       return;
     }
 
-    if (recordingUrl.trim() && !extractYouTubeVideoId(recordingUrl.trim())) {
+    if (isRecordingRequired) {
+      const trimmedRecording = recordingUrl.trim();
+      if (!trimmedRecording) {
+        setRecordingUrlError(
+          "Vui lòng nhập link video YouTube (recording) cho lớp có từ 2 học sinh trở lên.",
+        );
+        toast.error(
+          "Vui lòng nhập link video YouTube (recording) cho lớp có từ 2 học sinh trở lên.",
+        );
+        return;
+      }
+      if (!extractYouTubeVideoId(trimmedRecording)) {
+        setRecordingUrlError("Link video YouTube không hợp lệ.");
+        toast.error("Link video YouTube không hợp lệ.");
+        return;
+      }
+    } else if (
+      recordingUrl.trim() &&
+      !extractYouTubeVideoId(recordingUrl.trim())
+    ) {
       setRecordingUrlError("Link video YouTube không hợp lệ.");
       toast.error("Link video YouTube không hợp lệ.");
       return;
@@ -973,9 +993,12 @@ export default function AddSessionPopup({
                   <div className="flex flex-col gap-1.5 text-sm font-medium text-text-primary">
                     <label htmlFor="add-session-recording-url" className="flex items-center gap-1.5">
                       <span>Link video YouTube (recording)</span>
-                      <span className="text-xs font-normal text-text-muted">
-                        (Không bắt buộc)
-                      </span>
+                      {isRecordingRequired ? <RequiredMark /> : null}
+                      {isRecordingRequired ? (
+                        <span className="text-xs font-normal text-text-muted">
+                          (Bắt buộc đối với lớp từ 2 học sinh)
+                        </span>
+                      ) : null}
                     </label>
                     <input
                       id="add-session-recording-url"

--- a/apps/web/components/admin/session/SessionHistoryTable.tsx
+++ b/apps/web/components/admin/session/SessionHistoryTable.tsx
@@ -1351,7 +1351,22 @@ export default function SessionHistoryTable({
       }
     }
 
-    if (
+    const sessionStudentCount =
+      editingSession.attendance?.length ?? attendanceItems.length;
+    const isRecordingRequired = sessionStudentCount >= 2;
+    if (isRecordingRequired) {
+      const trimmedRecording = editRecordingUrl.trim();
+      if (!trimmedRecording) {
+        toast.error(
+          "Vui lòng nhập link video YouTube (recording) cho lớp có từ 2 học sinh trở lên.",
+        );
+        return;
+      }
+      if (!extractYouTubeVideoId(trimmedRecording)) {
+        toast.error("Link video YouTube không hợp lệ.");
+        return;
+      }
+    } else if (
       editRecordingUrl.trim() &&
       !extractYouTubeVideoId(editRecordingUrl.trim())
     ) {
@@ -3072,9 +3087,14 @@ export default function SessionHistoryTable({
                     <div className="flex flex-col gap-1.5 text-sm font-medium text-text-primary">
                       <label htmlFor="edit-session-recording-url" className="flex items-center gap-1.5">
                         <span>Link video YouTube (recording)</span>
-                        <span className="text-xs font-normal text-text-muted">
-                          (Không bắt buộc)
-                        </span>
+                        {(editingSession?.attendance?.length ?? attendanceItems.length) >= 2 ? (
+                          <RequiredMark />
+                        ) : null}
+                        {(editingSession?.attendance?.length ?? attendanceItems.length) >= 2 ? (
+                          <span className="text-xs font-normal text-text-muted">
+                            (Bắt buộc đối với lớp từ 2 học sinh)
+                          </span>
+                        ) : null}
                       </label>
                       <input
                         id="edit-session-recording-url"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -55,10 +55,6 @@ Mọi thay đổi đáng kể của dự án được ghi lại tại file này.
 
 ### Changed
 
-- **Hotfix — Link video YouTube (recording) không còn bắt buộc khi tạo/sửa buổi học:**
-  - **Backend:** `SessionCreateService` và `SessionUpdateService` bỏ validation bắt buộc `recordingUrl` khi lớp có $\ge 2$ học sinh (rule thêm ở mục "Bắt buộc nhập Link video YouTube..." bên dưới, nay đảo ngược). `recordingUrl` luôn optional cho mọi lớp/mọi actor; nếu có nhập, format YouTube vẫn chưa được validate ở backend (chỉ validate ở frontend, không đổi trong hotfix này).
-  - **Frontend:** `AddSessionPopup` (tạo buổi học) và `SessionHistoryTable` (sửa buổi học) bỏ dấu bắt buộc và chặn submit khi thiếu `recordingUrl`; vẫn giữ validate định dạng YouTube (`extractYouTubeVideoId`) khi người dùng có nhập link.
-
 - **Panel Thêm chuyên đề — default tab + cây (#87):** Mở **Thêm chuyên đề** mặc định tab **Thêm từ khoá** khi khoá học của lớp còn chuyên đề; fallback **Tạo mới cho lớp** nếu không có topic để chọn. `CourseTopicPicker` đổi từ list phẳng nhóm `chapterTitle` sang cây Chủ đề → Chuyên đề có expand/collapse (mobile-first). Không đổi API/schema.
 
 - **Buổi học không điểm danh (`noAttendance`) — backend guard khi cập nhật session:**


### PR DESCRIPTION
Revert PR #92. Hotfix cho rule recordingUrl chuyển sang merge thẳng vào `main` (đúng quy trình hotfix), không qua `dev` để tránh kéo theo các tính năng chưa release trên `dev` khi lên production.

`dev` quay lại rule cũ (recordingUrl bắt buộc khi lớp >= 2 học sinh). Hotfix thực tế theo dõi ở PR nhánh mới từ `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SqxEDMRfCMXd6nDBaafiPM