### PR TITLE
hotfix(session): bỏ bắt buộc recordingUrl khi tạo/sửa buổi học

### DIFF
--- a/apps/api/src/session/session-create.service.spec.ts
+++ b/apps/api/src/session/session-create.service.spec.ts
@@ -222,9 +222,9 @@ describe('SessionCreateService', () => {
     expect(createSessionSpy.mock.calls[0][0].allowanceAmount).toBeUndefined();
   });
 
-  it('throws BadRequestException when creating session with >= 2 students without recordingUrl', async () => {
+  it('allows creating session with >= 2 students without recordingUrl (recording is optional)', async () => {
     mockPrisma.$transaction.mockImplementation(async (callback: never) => {
-      const tx = {
+      const tx = baseTx({
         classTeacher: {
           findUnique: jest.fn().mockResolvedValue({
             id: 'ct-1',
@@ -239,6 +239,7 @@ describe('SessionCreateService', () => {
           }),
         },
         customerCareService: { findMany: jest.fn().mockResolvedValue([]) },
+        staffInfo: { findMany: jest.fn().mockResolvedValue([]) },
         studentClass: {
           findMany: jest.fn().mockResolvedValue([
             {
@@ -255,36 +256,52 @@ describe('SessionCreateService', () => {
             },
           ]),
         },
-      };
+        session: {
+          create: jest.fn().mockResolvedValue({
+            id: 'session-no-recording',
+            attendance: [
+              { id: 'att-1', studentId: 'student-1' },
+              { id: 'att-2', studentId: 'student-2' },
+            ],
+          }),
+        },
+      });
       return (callback as (tx: unknown) => Promise<unknown>)(tx);
     });
     scheduleRulesService.assertSessionMatchesDeclaredSchedule.mockResolvedValue(
-      null,
+      { makeupEventId: null },
+    );
+    validationService.parseSessionDate.mockReturnValue(new Date('2026-03-20'));
+    validationService.normalizeCoefficient.mockReturnValue(1);
+    validationService.isTuitionChargeableStatus.mockReturnValue(true);
+    validationService.resolveChargeableAttendanceTuitionFee.mockReturnValue(
+      100000,
+    );
+    validationService.resolveDefaultStudentTuitionPerSession.mockReturnValue(
+      100000,
     );
 
-    await expect(
-      service.createSession({
-        classId: 'class-1',
-        teacherId: 'teacher-1',
-        date: '2026-03-20',
-        lessonContent: '<p>Nội dung</p>',
-        homework: '<p>BTVN</p>',
-        tutorial: '<p>Tutorial</p>',
-        attendance: [
-          {
-            studentId: 'student-1',
-            status: AttendanceStatus.present,
-            notes: null,
-          },
-          {
-            studentId: 'student-2',
-            status: AttendanceStatus.present,
-            notes: null,
-          },
-        ],
-      }),
-    ).rejects.toThrow(
-      'Link video YouTube (recording) là bắt buộc đối với lớp có từ 2 học sinh trở lên.',
-    );
+    const result = await service.createSession({
+      classId: 'class-1',
+      teacherId: 'teacher-1',
+      date: '2026-03-20',
+      lessonContent: '<p>Nội dung</p>',
+      homework: '<p>BTVN</p>',
+      tutorial: '<p>Tutorial</p>',
+      attendance: [
+        {
+          studentId: 'student-1',
+          status: AttendanceStatus.present,
+          notes: null,
+        },
+        {
+          studentId: 'student-2',
+          status: AttendanceStatus.present,
+          notes: null,
+        },
+      ],
+    });
+
+    expect(result.id).toBe('session-no-recording');
   });
 });

--- a/apps/api/src/session/session-create.service.spec.ts
+++ b/apps/api/src/session/session-create.service.spec.ts
@@ -4,6 +4,9 @@ jest.mock('../prisma/prisma.service', () => ({
 jest.mock('./session-student-balance.service', () => ({
   SessionStudentBalanceService: class SessionStudentBalanceServiceMock {},
 }));
+jest.mock('../payroll/lesson-plan-head-commission.util', () => ({
+  syncLessonPlanHeadCommissions: jest.fn(),
+}));
 
 import { AttendanceStatus, StaffRole, UserRole } from '../../generated/enums';
 import { SessionCreateService } from './session-create.service';
@@ -32,6 +35,7 @@ describe('SessionCreateService', () => {
     validateSessionCommentFields: jest.fn(),
     isTuitionChargeableStatus: jest.fn().mockReturnValue(true),
     resolveChargeableAttendanceTuitionFee: jest.fn(),
+    resolveDefaultStudentTuitionPerSession: jest.fn(),
     parseSessionDate: jest.fn(),
     parseSessionTime: jest.fn(),
     normalizeCoefficient: jest.fn(),
@@ -57,6 +61,19 @@ describe('SessionCreateService', () => {
   const actionHistoryService = {
     recordCreate: jest.fn(),
   };
+
+  function baseTx(overrides: Record<string, unknown> = {}) {
+    return {
+      staffTaxDeductionOverride: {
+        findFirst: jest.fn().mockResolvedValue(null),
+      },
+      roleTaxDeductionRate: { findFirst: jest.fn().mockResolvedValue(null) },
+      walletTransactionsHistory: {
+        createManyAndReturn: jest.fn().mockResolvedValue([]),
+      },
+      ...overrides,
+    };
+  }
 
   let service: SessionCreateService;
 

--- a/apps/api/src/session/session-create.service.ts
+++ b/apps/api/src/session/session-create.service.ts
@@ -226,15 +226,6 @@ export class SessionCreateService {
             );
           }
 
-          if (uniqueAttendanceStudentIds.size >= 2) {
-            const recording = data.recordingUrl?.trim();
-            if (!recording) {
-              throw new BadRequestException(
-                'Link video YouTube (recording) là bắt buộc đối với lớp có từ 2 học sinh trở lên.',
-              );
-            }
-          }
-
           const coefficient =
             this.sessionValidationService.normalizeCoefficient(
               data.coefficient,

--- a/apps/api/src/session/session-update.service.spec.ts
+++ b/apps/api/src/session/session-update.service.spec.ts
@@ -32,6 +32,15 @@ describe('SessionUpdateService', () => {
     staffTaxDeductionOverride: {
       findFirst: jest.fn(),
     },
+    studentInfo: {
+      findMany: jest.fn(),
+    },
+    attendance: {
+      findMany: jest.fn(),
+    },
+    staffInfo: {
+      findMany: jest.fn(),
+    },
   };
 
   const accessService = {
@@ -75,6 +84,9 @@ describe('SessionUpdateService', () => {
     mockPrisma.classTeacher.findUnique.mockResolvedValue(null);
     mockPrisma.roleTaxDeductionRate.findFirst.mockResolvedValue(null);
     mockPrisma.staffTaxDeductionOverride.findFirst.mockResolvedValue(null);
+    mockPrisma.studentInfo.findMany.mockResolvedValue([]);
+    mockPrisma.attendance.findMany.mockResolvedValue([]);
+    mockPrisma.staffInfo.findMany.mockResolvedValue([]);
     service = new SessionUpdateService(
       mockPrisma as never,
       accessService as never,
@@ -393,28 +405,34 @@ describe('SessionUpdateService', () => {
     );
   });
 
-  it('throws BadRequestException when updating session with >= 2 students without recordingUrl', async () => {
-    mockPrisma.session.findUnique.mockResolvedValueOnce({
+  it('allows updating session with >= 2 students without recordingUrl (recording is optional)', async () => {
+    mockPrisma.session.findUnique
+      .mockResolvedValueOnce({
+        id: 'session-1',
+        classId: 'class-1',
+        teacherId: 'teacher-1',
+        date: new Date('2026-03-15T00:00:00.000Z'),
+        teacherPaymentStatus: SessionPaymentStatus.unpaid,
+        recordingUrl: null,
+        class: { name: 'Toán 10A' },
+        attendance: [
+          { id: 'att-1', studentId: 'student-1' },
+          { id: 'att-2', studentId: 'student-2' },
+        ],
+      })
+      .mockResolvedValueOnce({
+        id: 'session-1',
+        attendance: [
+          { id: 'att-1', studentId: 'student-1' },
+          { id: 'att-2', studentId: 'student-2' },
+        ],
+      });
+
+    await service.updateSession({
       id: 'session-1',
-      classId: 'class-1',
-      teacherId: 'teacher-1',
-      date: new Date('2026-03-15T00:00:00.000Z'),
-      teacherPaymentStatus: SessionPaymentStatus.unpaid,
-      recordingUrl: null,
-      class: { name: 'Toán 10A' },
-      attendance: [
-        { id: 'att-1', studentId: 'student-1' },
-        { id: 'att-2', studentId: 'student-2' },
-      ],
+      recordingUrl: '',
     });
 
-    await expect(
-      service.updateSession({
-        id: 'session-1',
-        recordingUrl: '',
-      }),
-    ).rejects.toThrow(
-      'Link video YouTube (recording) là bắt buộc đối với lớp có từ 2 học sinh trở lên.',
-    );
+    expect(mockPrisma.session.update).toHaveBeenCalled();
   });
 });

--- a/apps/api/src/session/session-update.service.spec.ts
+++ b/apps/api/src/session/session-update.service.spec.ts
@@ -433,6 +433,10 @@ describe('SessionUpdateService', () => {
       recordingUrl: '',
     });
 
-    expect(mockPrisma.session.update).toHaveBeenCalled();
+    const updateArgs = mockPrisma.session.update.mock.calls[0][0];
+    expect(updateArgs).toMatchObject({
+      where: { id: 'session-1' },
+      data: { recordingUrl: null },
+    });
   });
 });

--- a/apps/api/src/session/session-update.service.ts
+++ b/apps/api/src/session/session-update.service.ts
@@ -913,22 +913,6 @@ export class SessionUpdateService {
             )
           : undefined;
 
-        const targetStudentCount =
-          data.attendance !== undefined
-            ? data.attendance.length
-            : existingSession.attendance.length;
-        if (targetStudentCount >= 2) {
-          const effectiveRecordingUrl =
-            data.recordingUrl !== undefined
-              ? (data.recordingUrl?.trim() ?? '')
-              : (existingSession.recordingUrl?.trim() ?? '');
-          if (!effectiveRecordingUrl) {
-            throw new BadRequestException(
-              'Link video YouTube (recording) là bắt buộc đối với lớp có từ 2 học sinh trở lên.',
-            );
-          }
-        }
-
         const balanceStudentIds = Array.from(
           new Set([
             ...existingSession.attendance.map(

--- a/apps/web/components/admin/class/AddSessionPopup.tsx
+++ b/apps/web/components/admin/class/AddSessionPopup.tsx
@@ -271,7 +271,6 @@ export default function AddSessionPopup({
   const [homeworkError, setHomeworkError] = useState("");
   const [tutorialError, setTutorialError] = useState("");
   const [recordingUrlError, setRecordingUrlError] = useState("");
-  const isRecordingRequired = students.length >= 2;
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isTrialLesson, setIsTrialLesson] = useState(false);
   const [teacherPaymentStatus, setTeacherPaymentStatus] = useState<string>("unpaid");
@@ -600,26 +599,7 @@ export default function AddSessionPopup({
       return;
     }
 
-    if (isRecordingRequired) {
-      const trimmedRecording = recordingUrl.trim();
-      if (!trimmedRecording) {
-        setRecordingUrlError(
-          "Vui lòng nhập link video YouTube (recording) cho lớp có từ 2 học sinh trở lên.",
-        );
-        toast.error(
-          "Vui lòng nhập link video YouTube (recording) cho lớp có từ 2 học sinh trở lên.",
-        );
-        return;
-      }
-      if (!extractYouTubeVideoId(trimmedRecording)) {
-        setRecordingUrlError("Link video YouTube không hợp lệ.");
-        toast.error("Link video YouTube không hợp lệ.");
-        return;
-      }
-    } else if (
-      recordingUrl.trim() &&
-      !extractYouTubeVideoId(recordingUrl.trim())
-    ) {
+    if (recordingUrl.trim() && !extractYouTubeVideoId(recordingUrl.trim())) {
       setRecordingUrlError("Link video YouTube không hợp lệ.");
       toast.error("Link video YouTube không hợp lệ.");
       return;
@@ -978,12 +958,9 @@ export default function AddSessionPopup({
                   <div className="flex flex-col gap-1.5 text-sm font-medium text-text-primary">
                     <label htmlFor="add-session-recording-url" className="flex items-center gap-1.5">
                       <span>Link video YouTube (recording)</span>
-                      {isRecordingRequired ? <RequiredMark /> : null}
-                      {isRecordingRequired ? (
-                        <span className="text-xs font-normal text-text-muted">
-                          (Bắt buộc đối với lớp từ 2 học sinh)
-                        </span>
-                      ) : null}
+                      <span className="text-xs font-normal text-text-muted">
+                        (Không bắt buộc)
+                      </span>
                     </label>
                     <input
                       id="add-session-recording-url"

--- a/apps/web/components/admin/session/SessionHistoryTable.tsx
+++ b/apps/web/components/admin/session/SessionHistoryTable.tsx
@@ -1351,22 +1351,7 @@ export default function SessionHistoryTable({
       }
     }
 
-    const sessionStudentCount =
-      editingSession.attendance?.length ?? attendanceItems.length;
-    const isRecordingRequired = sessionStudentCount >= 2;
-    if (isRecordingRequired) {
-      const trimmedRecording = editRecordingUrl.trim();
-      if (!trimmedRecording) {
-        toast.error(
-          "Vui lòng nhập link video YouTube (recording) cho lớp có từ 2 học sinh trở lên.",
-        );
-        return;
-      }
-      if (!extractYouTubeVideoId(trimmedRecording)) {
-        toast.error("Link video YouTube không hợp lệ.");
-        return;
-      }
-    } else if (
+    if (
       editRecordingUrl.trim() &&
       !extractYouTubeVideoId(editRecordingUrl.trim())
     ) {
@@ -3081,14 +3066,9 @@ export default function SessionHistoryTable({
                     <div className="flex flex-col gap-1.5 text-sm font-medium text-text-primary">
                       <label htmlFor="edit-session-recording-url" className="flex items-center gap-1.5">
                         <span>Link video YouTube (recording)</span>
-                        {(editingSession?.attendance?.length ?? attendanceItems.length) >= 2 ? (
-                          <RequiredMark />
-                        ) : null}
-                        {(editingSession?.attendance?.length ?? attendanceItems.length) >= 2 ? (
-                          <span className="text-xs font-normal text-text-muted">
-                            (Bắt buộc đối với lớp từ 2 học sinh)
-                          </span>
-                        ) : null}
+                        <span className="text-xs font-normal text-text-muted">
+                          (Không bắt buộc)
+                        </span>
                       </label>
                       <input
                         id="edit-session-recording-url"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,12 @@ Mọi thay đổi đáng kể của dự án được ghi lại tại file này.
 
 ## [Unreleased]
 
+### Changed
+
+- **Hotfix — Link video YouTube (recording) không còn bắt buộc khi tạo/sửa buổi học:**
+  - **Backend:** `SessionCreateService` và `SessionUpdateService` bỏ validation bắt buộc `recordingUrl` khi lớp có $\ge 2$ học sinh. `recordingUrl` luôn optional cho mọi lớp/mọi actor; format YouTube vẫn chưa được validate ở backend (chỉ validate ở frontend, không đổi trong hotfix này).
+  - **Frontend:** `AddSessionPopup` (tạo buổi học) và `SessionHistoryTable` (sửa buổi học) bỏ dấu bắt buộc và chặn submit khi thiếu `recordingUrl`; vẫn giữ validate định dạng YouTube (`extractYouTubeVideoId`) khi người dùng có nhập link.
+
 ### Added
 
 - **Migration — Backfill hồ sơ `student_info` cho toàn bộ tài khoản `users` có role `student`:**


### PR DESCRIPTION
## Vấn đề

`SessionCreateService`/`SessionUpdateService` bắt buộc `recordingUrl` (link video YouTube) khi buổi học có ≥ 2 học sinh, chặn gia sư tạo/sửa buổi học nếu quên/chưa có link recording. Đây là hotfix trực tiếp vào `main` (không qua `dev`, vì `dev` đang mang nhiều tính năng chưa release).

## Thay đổi

- **Backend:** Xoá validation bắt buộc `recordingUrl` khi lớp ≥ 2 học sinh ở cả `SessionCreateService` và `SessionUpdateService`. `recordingUrl` optional cho mọi lớp/mọi actor.
- **Frontend:** `AddSessionPopup` (tạo buổi học) và `SessionHistoryTable` (sửa buổi học) bỏ dấu bắt buộc, không còn chặn submit khi thiếu `recordingUrl`; UI đổi nhãn thành "(Không bắt buộc)".
- Vẫn giữ nguyên validate định dạng YouTube (`extractYouTubeVideoId`) khi người dùng có nhập link — chỉ ở frontend, không đổi behavior này.
- Cập nhật test tương ứng ở `session-create.service.spec.ts` và `session-update.service.spec.ts` (test throw cũ → test cho phép tạo/sửa thành công không cần `recordingUrl`).
- Cập nhật `docs/CHANGELOG.md`.

## Ngoài phạm vi

- Không thêm validate định dạng YouTube ở backend (gap này đã tồn tại từ trước, giữ nguyên theo quyết định của chủ dự án).
- Không viết ADR (thay đổi dễ đảo ngược, không có trade-off thực sự cần ghi lại).

## Verify

- `pnpm exec prisma generate` + `pnpm exec prisma validate` — OK
- `apps/api`: `tsc --noEmit` sạch; `jest src/session` — 55/55 pass; `eslint` trên các file đã sửa — sạch (không phát sinh lỗi mới, đã đối chiếu baseline `main` trước hotfix)
- `apps/web`: `tsc --noEmit` sạch; `eslint` trên 2 file đã sửa — 10 lỗi/cảnh báo còn lại đều là pre-existing (đã đối chiếu với baseline, không phải do thay đổi này)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SqxEDMRfCMXd6nDBaafiPM